### PR TITLE
Update gotest.vim, fix -run flag, run from any file

### DIFF
--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -6,9 +6,9 @@ function! test#go#gotest#build_position(type, position) abort
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name) | let name = '-run '.shellescape(name, 1) | endif
-    return [a:position['file'], name]
+    return [name]
   elseif a:type == 'file'
-    return [a:position['file']]
+    return ['-run', a:position['file']]
   else
     return []
   endif


### PR DESCRIPTION
- Fix go test -run. If we run a file, only use the file name. If we run
  a targeted test, don't include the file name.