### PR TITLE
"Fix" go testing options since go doesn't test single files

### DIFF
--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -8,9 +8,9 @@ function! test#go#gotest#build_position(type, position) abort
     if !empty(name) | let name = '-run '.shellescape(name, 1) | endif
     return [name]
   elseif a:type == 'file'
-    return ['-run', a:position['file']]
-  else
     return []
+  else
+    return ['./...']
   endif
 endfunction
 


### PR DESCRIPTION
- 'file' option will test all the *_test.go files in the current directory by running 'go test'.
  Go doesn't have a concept of running all tests in a single file without some tricky file inclusion.

- 'suite' option will run all the tests in the current directory and all subdirectories by running 'go test ./...'.