### PR TITLE
Add neoterm strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ let test#strategy = "dispatch"
 | :-----:                                                                         | :-----:    | :----------                                                                      |
 | **Basic**&nbsp;(default)                                                        | `basic`    | Runs test commands with `:!`, which switches your Vim to the terminal.           |
 | **Neovim**                                                                      | `neovim`   | Runs test commands with `:terminal`, which spawns a terminal inside your Neovim. |
-| [**Neoterm**](https://github.com/kassio/neoterm)                                | `neoterm`  | Runs test commands with `:T`, see neoterm docs for deisplay customization.       |
+| [**Neoterm**](https://github.com/kassio/neoterm)                                | `neoterm`  | Runs test commands with `:T`, see neoterm docs for display customization.        |
 | [**Dispatch.vim**](https://github.com/tpope/vim-dispatch)                       | `dispatch` | Runs test commands with `:Dispatch`.                                             |
 | [**Vimux**](https://github.com/benmills/vimux)                                  | `vimux`    | Runs test commands in a small tmux pane at the bottom of your terminal.          |
 | [**Tslime.vim**](https://github.com/kikijump/tslime.vim)                        | `tslime`   | Runs test commands in a tmux pane you specify.                                   |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ let test#strategy = "dispatch"
 | :-----:                                                                         | :-----:    | :----------                                                                      |
 | **Basic**&nbsp;(default)                                                        | `basic`    | Runs test commands with `:!`, which switches your Vim to the terminal.           |
 | **Neovim**                                                                      | `neovim`   | Runs test commands with `:terminal`, which spawns a terminal inside your Neovim. |
+| [**Neoterm**](https://github.com/kassio/neoterm)                                | `neoterm`  | Runs test commands with `:T`, see neoterm docs for deisplay customization.       |
 | [**Dispatch.vim**](https://github.com/tpope/vim-dispatch)                       | `dispatch` | Runs test commands with `:Dispatch`.                                             |
 | [**Vimux**](https://github.com/benmills/vimux)                                  | `vimux`    | Runs test commands in a small tmux pane at the bottom of your terminal.          |
 | [**Tslime.vim**](https://github.com/kikijump/tslime.vim)                        | `tslime`   | Runs test commands in a tmux pane you specify.                                   |

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -14,6 +14,10 @@ function! test#strategy#neovim(cmd) abort
   enew | call termopen(a:cmd) | startinsert
 endfunction
 
+function! test#strategy#neoterm(cmd) abort
+  execute 'T '.a:cmd
+endfunction
+
 function! test#strategy#vtr(cmd) abort
   call VtrSendCommand(s:pretty_command(a:cmd), 1)
 endfunction


### PR DESCRIPTION
Neoterm provides better customization options for how terminals are spawned in
neovim. It behaves more like Dispatch in that it can send the command to a new
split or an existing split if there is one already open. Neoterm has some built in test 
commands but they aren't as good as the ones provided by vim-test. This strategy 
allows you to get the best of both worlds.