### PR TITLE
allow underscores and numbers in python class names

### DIFF
--- a/autoload/test/python.vim
+++ b/autoload/test/python.vim
@@ -1,4 +1,4 @@
 let test#python#levels = [
   \ '\v^\s*def (test_\w+)',
-  \ '\v^\s*class ([A-Za-z.]+)',
+  \ '\v^\s*class (\w+)',
 \]

--- a/spec/fixtures/nose/test_class.py
+++ b/spec/fixtures/nose/test_class.py
@@ -5,3 +5,7 @@ class TestNumbers:
 class TestSubclass(Subclass):
     def test_numbers(self):
         assert 1 == 1
+
+class Test_underscores_and_123(Subclass):
+    def test_underscores(self):
+        assert 1 == 1


### PR DESCRIPTION
The fix for issue #29 will still fail when the class name contains
underscores or numbers, both of which are valid in python.  I noticed
that the regex also allows dots, which are not valid in a python class
name ( http://stackoverflow.com/a/10120327 )