### PR TITLE
allow "test" to be anywhere in a filename

### DIFF
--- a/autoload/test/python/nose.vim
+++ b/autoload/test/python/nose.vim
@@ -1,5 +1,5 @@
 function! test#python#nose#test_file(file) abort
-  if fnamemodify(a:file, ':t') =~# '\v[Tt]est.*\.py$'
+  if fnamemodify(a:file, ':t') =~# '\v(^|[\b_\.-])[Tt]est.*\.py$'
     if exists('g:test#python#runner')
       return g:test#python#runner == 'nose'
     else

--- a/autoload/test/python/nose.vim
+++ b/autoload/test/python/nose.vim
@@ -1,5 +1,5 @@
 function! test#python#nose#test_file(file) abort
-  if fnamemodify(a:file, ':t') =~# '\v^[Tt]est.*\.py$'
+  if fnamemodify(a:file, ':t') =~# '\v[Tt]est.*\.py$'
     if exists('g:test#python#runner')
       return g:test#python#runner == 'nose'
     else


### PR DESCRIPTION
by default, nose looks for a file with "test" at the beginning of the
name, or anywhere in the filename after a word boundary like underscore
or dot.

http://nose.readthedocs.org/en/latest/api/config.html