### PR TITLE
PHPUnit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently the following testing frameworks are supported:
 | **Shell**      | Bats                                  |
 | **VimScript**  | VSpec, Vader.vim                      |
 | **Lua**        | Busted                                |
+| **PHP**        | PHPUnit                               |
 
 ## Idea
 

--- a/autoload/test/php.vim
+++ b/autoload/test/php.vim
@@ -1,0 +1,4 @@
+let test#php#levels = [
+  \ '\v^\s*function (test\w+)',
+  \ '\v^\s*class (\w+)',
+\]

--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -1,0 +1,23 @@
+function! test#php#phpunit#test_file(file) abort
+  return a:file =~# '\v(t|T)est\.php$'
+endfunction
+
+function! test#php#phpunit#build_position(type, position) abort
+  if a:type == 'nearest' || a:type == 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#php#phpunit#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#php#phpunit#executable() abort
+  if filereadable('vendor/bin/phpunit')
+    return 'vendor/bin/phpunit'
+  else
+    return 'phpunit'
+  endif
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -103,6 +103,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:Busted*
 :Busted [args]               Uses the `busted` command.
 
+                                                *test-:PHPUnit*
+:PHPUnit [args]              Uses the `phpunit` command.
+
 STRATEGIES                                      *test-strategies*
 
 Multiple strategies are supported for running tests.

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -22,6 +22,7 @@ call s:extend(g:test#runners, {
   \ 'Shell':      ['Bats'],
   \ 'VimL':       ['VSpec', 'Vader'],
   \ 'Lua':        ['Busted'],
+  \ 'PHP':        ['PHPUnit'],
 \})
 
 command! -nargs=* -bar TestNearest call test#run('nearest', <q-args>)

--- a/spec/fixtures/phpunit/NormalTest.php
+++ b/spec/fixtures/phpunit/NormalTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit_Framework_TestCase;
+
+class NormalTest extends PHPUnit_Framework_TestCase
+{
+    public function testShouldAddTwoNumbers()
+    {
+        $this->assertEquals(2, 1+1);
+    }
+}

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -1,0 +1,35 @@
+source spec/helpers.vim
+
+describe "PHPUnit"
+
+  before
+    cd spec/fixtures/phpunit
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view NormalTest.php
+    TestFile
+
+    Expect g:test#last_command == 'phpunit NormalTest.php'
+  end
+
+  it "runs test suites"
+    view NormalTest.php
+    TestSuite
+
+    Expect g:test#last_command == 'phpunit'
+  end
+
+  it "doesn't recognize files that don't end with 'Test'"
+    view normal.php
+    TestFile
+
+    Expect exists('g:test#last_command') == 0
+  end
+
+end


### PR DESCRIPTION
I am trying to create a pull request to add PHPUnit support but at the moment I am having trouble getting my tests to pass as `Expect exists('g:test#last_command') == 1` is failing. Is there something else I need to do to hook it in?