### PR TITLE
Look for phpunit in standard Composer ./vendor/bin and ./bin directories

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -15,8 +15,10 @@ function! test#php#phpunit#build_args(args) abort
 endfunction
 
 function! test#php#phpunit#executable() abort
-  if filereadable('vendor/bin/phpunit')
-    return 'vendor/bin/phpunit'
+  if filereadable('./vendor/bin/phpunit')
+    return './vendor/bin/phpunit'
+  elseif filereadable('./bin/phpunit')
+    return './bin/phpunit'
   else
     return 'phpunit'
   endif


### PR DESCRIPTION
This updates the phpunit runner to look for phpunit in standard Composer ./vendor/bin and ./bin directories

![](https://33.media.tumblr.com/d8a3b71a782db050ad8c0394a1f6265d/tumblr_ns9r6iK7R91rq7to9o1_500.gif)