### PR TITLE
Change django detection by assuming current directory is root (and has manage.py file).

### DIFF
--- a/autoload/test/python/djangotest.vim
+++ b/autoload/test/python/djangotest.vim
@@ -4,7 +4,11 @@ endif
 
 function! test#python#djangotest#test_file(file) abort
   if fnamemodify(a:file, ':t') =~# g:test#python#djangotest#file_pattern
-    return !empty(findfile('manage.py', '.;'))
+    if exists('g:test#python#runner')
+      return g:test#python#runner == 'djangotest'
+    else
+      return (executable('django-admin') && executable(getcwd() . '/manage.py'))
+    endif
   endif
 endfunction
 
@@ -29,27 +33,16 @@ function! test#python#djangotest#build_args(args) abort
 endfunction
 
 function! test#python#djangotest#executable() abort
-  return s:manage_py_path() . '/manage.py test'
+  return getcwd() . '/manage.py test'
 endfunction
 
 function! s:get_import_path(filepath) abort
-  " Get the full path to the file on disk (without extension).
-  let path = fnamemodify(a:filepath, ':p:r')
-  " Remove everything up to the folder with the manage.py.
-  let path = substitute(path, s:manage_py_path() . '/', '', 'g')
-  " Convert the slashes to periods.
+  " Get path to file from cwd and without extension.
+  let path = fnamemodify(a:filepath, ':.:r')
+  " Replace the /'s in the file path with .'s
   let path = substitute(path, '\/', '.', 'g')
   return path
 endfunction!
-
-function! s:manage_py_path() abort
-  " Go up the tree looking for the manage.py file and return its path.
-  let path = findfile('manage.py', '.;')
-  " Get the full path, even if we're in the current directory.
-  let path = fnamemodify(path, ':p')
-  " Strip the /manage.py from the end.
-  return substitute(path, '/manage.py', '', '')
-endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#python#patterns)

--- a/spec/djangotest_spec.vim
+++ b/spec/djangotest_spec.vim
@@ -9,9 +9,8 @@ endfunction
 describe "DjangoTest"
 
   before
-    " We start off in the module directory so we can test locating and running
-    " tests from the path of the manage.py executable.
-    cd spec/fixtures/django/module
+    let g:test#python#runner = 'djangotest'
+    cd spec/fixtures/django
   end
 
   after
@@ -20,29 +19,29 @@ describe "DjangoTest"
   end
 
   it "runs nearest tests"
-    view +2 test_class.py
+    view +2 module/test_class.py
     TestNearest
 
     Expect g:test#last_command == 'manage.py test module.test_class.TestNumbers.test_numbers'
 
-    view +5 test_class.py
+    view +5 module/test_class.py
     TestNearest
 
     Expect g:test#last_command == 'manage.py test module.test_class.TestSubclass'
 
-    view +1 test_class.py
+    view +1 module/test_class.py
     TestNearest
 
     Expect g:test#last_command == 'manage.py test module.test_class.TestNumbers'
 
-    view +1 test_method.py
+    view +1 module/test_method.py
     TestNearest
 
     Expect g:test#last_command == 'manage.py test module.test_method.test_numbers'
   end
 
   it "runs file test if nearest test couldn't be found"
-    view +1 test_method.py
+    view +1 module/test_method.py
     normal O
     TestNearest
 
@@ -50,7 +49,7 @@ describe "DjangoTest"
   end
 
   it "runs file tests"
-    view test_class.py
+    view module/test_class.py
     TestFile
 
     Expect g:test#last_command == 'manage.py test module.test_class'
@@ -58,14 +57,6 @@ describe "DjangoTest"
 
   it "runs test suites and finds manage.py"
     view test_class.py
-    TestSuite
-
-    Expect g:test#last_command == 'manage.py test'
-  end
-
-  it "can find manage.py in the cwd"
-    cd ..
-    view module/test_class.py
     TestSuite
 
     Expect g:test#last_command == 'manage.py test'

--- a/spec/fixtures/django/manage.py
+++ b/spec/fixtures/django/manage.py
@@ -1,3 +1,0 @@
-# This is a sample file used so that Django
-# tests have a target for locating the
-# manage.py executable.


### PR DESCRIPTION
This commit does a few things:

1) The original Django runner was attempting to be too clever in trying to deal with cases where the current working directory wasn't root and therefore didn't have a  manage.py file we could run tests from. Instead, we went hunting for it up the file tree. vim-test as a basic constraint, however, requires the working directory to be root, so we can remove the cleverness and make the code much simpler and more performant.

2) Because we were searching up the paths looking for a manage.py file, we could encounter false positives in trying to find the file (see #56). This should partially resolve that problem by not searching all up the tree for a manage.py file. However, some other python frameworks could have a manage.py in root, so to cover those cases we're now also checking that django is installed by looking for the `django-admin` executable.

3) We were not allowing the django test runner to be overridden with the `test#python#runner` variable, which could be problematic for those with python installed who wish to use a different test runner or people just generally running into our check not being sufficient. So, we're now checking for that setting as well.