### PR TITLE
javascript: alias "context" to "describe"

### DIFF
--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -1,4 +1,4 @@
 let test#javascript#patterns = {
   \ 'test':      ['\v^\s*it[( ]%("|'')(.*)%("|''),'],
-  \ 'namespace': ['\v^\s*describe[( ]%("|'')(.*)%("|''),'],
+  \ 'namespace': ['\v^\s*%(describe|context)[( ]%("|'')(.*)%("|''),'],
 \}

--- a/spec/fixtures/mocha/test/context.js
+++ b/spec/fixtures/mocha/test/context.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  context('Addition', function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});

--- a/spec/mocha_spec.vim
+++ b/spec/mocha_spec.vim
@@ -29,6 +29,23 @@ describe "Mocha"
       Expect g:test#last_command == 'mocha test/normal.js --grep ''Math Addition adds two numbers'''
     end
 
+    it "aliases context to describe"
+      view +1 test/context.js
+      TestNearest
+
+      Expect g:test#last_command == 'mocha test/context.js --grep ''Math'''
+
+      view +2 test/context.js
+      TestNearest
+
+      Expect g:test#last_command == 'mocha test/context.js --grep ''Math Addition'''
+
+      view +3 test/context.js
+      TestNearest
+
+      Expect g:test#last_command == 'mocha test/context.js --grep ''Math Addition adds two numbers'''
+    end
+
     it "runs CoffeeScript"
       view +1 test/normal.coffee
       TestNearest


### PR DESCRIPTION
Mocha's BDD test runner adds a `context` global, much like rspec's `context`:
https://mochajs.org/#bdd. Previously the namespace regex would miss this, which
would cause the grep to be incomplete. Updates the mocha regex to match the
word `context` in the same place as the word `describe`.

Adds tests that this new regex behaves as expected.