### PR TITLE
Can run nearest phpunit test marked with @test annotation

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -39,7 +39,12 @@ function! test#php#phpunit#executable() abort
 endfunction
 
 function! s:nearest_test(position)
-  let patterns = {'test': ['\vpublic function (test\w*)\('], 'namespace': []}
+  let patterns = {
+    \ 'test': [
+    \    '\vpublic function (test\w*)\(',
+    \    '\vpublic function (\w*)\('],
+    \ 'namespace': []
+    \}
   let name = test#base#nearest_test(a:position, patterns)
   return join(name['test'])
 endfunction

--- a/spec/fixtures/phpunit/NormalTest.php
+++ b/spec/fixtures/phpunit/NormalTest.php
@@ -31,4 +31,24 @@ class NormalTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals($expected, $a + $b);
     }
+
+    /**
+     * @test
+     */
+    public function aTestMarkedWithTestAnnotation()
+    {
+        $this->assertEquals(2, 4-21);
+    }
+
+    /**
+     * Possible comments
+     *
+     * @someOtherAnnotation
+     * @test
+     * @param foo bar
+     */
+    public function aTestMarkedWithTestAnnotationAndCrazyDocblock()
+    {
+        $this->assertEquals(2, 4-21);
+    }
 }

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -40,6 +40,18 @@ describe "PHPUnit"
     Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddToExpectedValue' NormalTest.php"
   end
 
+  it  "runs nearest test marked with @test annotation"
+    view +40 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotation' NormalTest.php"
+
+    view +50 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotationAndCrazyDocblock' NormalTest.php"
+  end
+
   it "runs test suites"
     view NormalTest.php
     TestSuite


### PR DESCRIPTION
The simplest solution was implemented, due to my lack of VimL knowledge. Now it works, but not because of the `@test` annotation, but because it is the nearest method.

The way it is it will consider any method as a test method. That may be considered a bug.

Of course it can be improved, but IMO it is better to see PHPUnit's message "no tests executed!" when cursor is near a non-test method than not being able to run a single method when it is an annotated method.