### PR TITLE
DjangoTest: launch manage.py with python

### DIFF
--- a/autoload/test/python/djangotest.vim
+++ b/autoload/test/python/djangotest.vim
@@ -7,7 +7,7 @@ function! test#python#djangotest#test_file(file) abort
     if exists('g:test#python#runner')
       return g:test#python#runner == 'djangotest'
     else
-      return filereadable('./manage.py') && executable('django-admin') 
+      return filereadable('python manage.py') && executable('django-admin') 
     endif
   endif
 endfunction
@@ -33,7 +33,7 @@ function! test#python#djangotest#build_args(args) abort
 endfunction
 
 function! test#python#djangotest#executable() abort
-  return './manage.py test'
+  return 'python manage.py test'
 endfunction
 
 function! s:get_import_path(filepath) abort

--- a/spec/djangotest_spec.vim
+++ b/spec/djangotest_spec.vim
@@ -16,22 +16,22 @@ describe "DjangoTest"
     view +2 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == './manage.py test module.test_class.TestNumbers.test_numbers'
+    Expect g:test#last_command == 'python manage.py test module.test_class.TestNumbers.test_numbers'
 
     view +5 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == './manage.py test module.test_class.TestSubclass'
+    Expect g:test#last_command == 'python manage.py test module.test_class.TestSubclass'
 
     view +1 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == './manage.py test module.test_class.TestNumbers'
+    Expect g:test#last_command == 'python manage.py test module.test_class.TestNumbers'
 
     view +1 module/test_method.py
     TestNearest
 
-    Expect g:test#last_command == './manage.py test module.test_method.test_numbers'
+    Expect g:test#last_command == 'python manage.py test module.test_method.test_numbers'
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -39,21 +39,21 @@ describe "DjangoTest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == './manage.py test module.test_method'
+    Expect g:test#last_command == 'python manage.py test module.test_method'
   end
 
   it "runs file tests"
     view module/test_class.py
     TestFile
 
-    Expect g:test#last_command == './manage.py test module.test_class'
+    Expect g:test#last_command == 'python manage.py test module.test_class'
   end
 
   it "runs test suites and finds manage.py"
     view test_class.py
     TestSuite
 
-    Expect g:test#last_command == './manage.py test'
+    Expect g:test#last_command == 'python manage.py test'
   end
 
 end


### PR DESCRIPTION
This allows manage.py to have no 'x' flag