### PR TITLE
Added djangonose plugin

### DIFF
--- a/autoload/test/python/djangonose.vim
+++ b/autoload/test/python/djangonose.vim
@@ -1,0 +1,50 @@
+if !exists('g:test#python#djangotest#file_pattern')
+  let g:test#python#djangotest#file_pattern = '^test_.*\.py$'
+endif
+
+function! test#python#djangotest#test_file(file) abort
+  if fnamemodify(a:file, ':t') =~# g:test#python#djangotest#file_pattern
+    if exists('g:test#python#runner')
+      return g:test#python#runner == 'djangotest'
+    else
+      return filereadable('python manage.py') && executable('django-admin') 
+    endif
+  endif
+endfunction
+
+function! test#python#djangotest#build_position(type, position) abort
+  let path = s:get_import_path(a:position['file'])
+  if a:type == 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      return [path . ':' . name]
+    else
+      return [path]
+    endif
+  elseif a:type == 'file'
+    return [path]
+  else
+    return []
+  endif
+endfunction
+
+function! test#python#djangotest#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#python#djangotest#executable() abort
+  return 'python manage.py test'
+endfunction
+
+function! s:get_import_path(filepath) abort
+  " Get path to file from cwd and without extension.
+  let path = fnamemodify(a:filepath, ':.:r')
+  " Replace the /'s in the file path with .'s
+  let path = substitute(path, '\/', '.', 'g')
+  return path
+endfunction!
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#python#patterns)
+  return join(name['namespace'] + name['test'], '.')
+endfunction


### PR DESCRIPTION
### Preface
I test django project with django-nose plugin.
It allows to enjoy all benefits of nosetests, but have different test location pattern, then unittest.
### Patch
I copied djangotest.vim, and changed line 20: replaced separator with ':' (was '.')
This is the only change I made to djangotest.vim

Looks like I am not following DRY principle here ;) but I am very new to vim plugins programming and don't know how to do it correctly.