### PR TITLE
Don't clear the screen before running tests

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -69,7 +69,11 @@ function! s:pretty_command(cmd) abort
   let clear = !s:Windows() ? 'clear' : 'cls'
   let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
 
-  return join([l:clear, l:echo, a:cmd], '; ')
+  if !exists('g:test#preserve_screen') || !g:test#preserve_screen
+    return join([l:clear, l:echo, a:cmd], '; ')
+  else
+    return join([l:echo, a:cmd], '; ')
+  endif
 endfunction
 
 function! s:Windows() abort


### PR DESCRIPTION
Provide a variable that can be used to prevent the screen from being
cleared before each test run.  Set `g:test#preserve_screen` to non-zero
to disable the clear screen functionality.

By default, the existing clear screen behavior is kept.