### PR TITLE
Add support for PHPUnit custom executable

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -29,6 +29,9 @@ function! test#php#phpunit#build_args(args) abort
 endfunction
 
 function! test#php#phpunit#executable() abort
+  if exists('g:test#php#phpunit#executable')
+    return g:test#php#phpunit#executable
+  endif
   if filereadable('./vendor/bin/phpunit')
     return './vendor/bin/phpunit'
   elseif filereadable('./bin/phpunit')


### PR DESCRIPTION
Hello,

My use case is running PHPUnit from inside a docker container. To accomplish this I create a bash script which wraps the docker command and parameters and call that instead of the phpunit executable, something like:

    ./run-tests.sh tests/

Unfortunately I do not have the necessary skills to write a test for the modification but I do hope you will consider merging it. 


