### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ Currently the following testing frameworks are supported:
 
 ## Idea
 
-Since Gary Bernhardt invented testing from Vim, there have been multiple
-plugins implementing this functionality (rspec.vim, vroom.vim etc). However,
-all of these solutions have bad designs, unclear ideas and aren't extendable.
-So I decided to create test.vim, featuring:
+There are many different plug-ins that allow running tests from Vim (rspec.vim,
+vroom.vim, etc). test.vim differs from these in that it ships with support for a
+wide range of languages, runners, and execution environments (see:
+[strategies](#strategies)) and is easily extended when you need to add more.
+test.vim features:
 
 * zero dependencies
 * zero configuration required (it Does the Right Thing™, see [**Philosophy**](https://github.com/janko-m/vim-test/wiki))


### PR DESCRIPTION
1. We can be reasonably certain that people ran tests from their editor
before Gary Bernhardt.

2. Criticisms of other projects as having "bad designs" or "unclear
ideas" are unsubstantiated and, frankly, unkind. They don't bolster the
case for using `test.vim`.