### PR TITLE
Use --no-ansi with PHPSpec if strategy doesn't support colors

### DIFF
--- a/autoload/test/php/phpspec.vim
+++ b/autoload/test/php/phpspec.vim
@@ -15,8 +15,11 @@ function! test#php#phpspec#build_position(type, position) abort
 endfunction
 
 function! test#php#phpspec#build_args(args) abort
-  let args = ['run'] + a:args
-  return args
+  if test#base#no_colors()
+    return ['run'] + ['--no-ansi'] + a:args
+  else
+    return ['run'] + a:args
+  endif
 endfunction
 
 function! test#php#phpspec#executable() abort


### PR DESCRIPTION
![](http://assets.itsnicethat.com/system/files/032016/56e68c417fa44cbbf3000001/images_slice_large/stephenvuillemin_nytimes_broadband_superman.gif?1457949957)