### PR TITLE
Test runner executable search depth and integration with phpunit executable search

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -38,6 +38,38 @@ function! test#php#phpunit#executable() abort
   endif
 endfunction
 
+function! s:search_local_executable(dir) abort
+  " Look for phpunit in Composer's vendor/bin and Symfony's bin directories
+  echo a:dir
+  if filereadable(a:dir . '/vendor/bin/phpunit')
+    return a:dir . '/vendor/bin/phpunit'
+  elseif filereadable(a:dir . '/bin/phpunit')
+    return a:dir . '/bin/phpunit'
+  else
+    return ''
+  endif
+endfunction
+
+function! test#php#phpunit#executable() abort
+  let phpunit_path = ''
+  let search_count = 0
+  let search_base_dir = expand("%:p:h")
+  while search_count < g:test#executable_search_depth
+    let phpunit_path = s:search_local_executable(search_base_dir)
+    if phpunit_path != ''
+        break
+    endif
+    let search_base_dir = search_base_dir . '/..'
+    let search_count = search_count + 1
+  endwhile
+
+  if filereadable(phpunit_path)
+    return phpunit_path
+  else
+    return 'phpunit'
+  endif
+endfunction
+
 function! s:nearest_test(position)
   let patterns = {
     \ 'test': [

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -27,6 +27,10 @@ call s:extend(g:test#runners, {
   \ 'Java':       ['MavenTest'],
 \})
 
+" Maximum upwards search depth constraint while searching for the test runner
+" executable.
+let g:test#executable_search_depth = 5
+
 let g:test#custom_strategies = get(g:, 'test#custom_strategies', {})
 let g:test#custom_transformations = get(g:, 'test#custom_transformations', {})
 let g:test#runner_commands = get(g:, 'test#runner_commands', [])


### PR DESCRIPTION
Search up the directory tree from a given test file for the phpunit executable until a match is found or g:test#executable_search_depth is reached.

Including @codeinabox since he has committed a few PHP-related patches.