### PR TITLE
Add support for JavaScript's Intern framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ let test#strategy = "dispatch"
 | **Terminal.app**                | `terminal` | Sends test commands to Terminal (useful in MacVim GUI).                          |
 | **iTerm2.app**                  | `iterm`    | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                     |
 
+In addition to setting a strategy globally, you can also set one per command:
+
+```
+:TestFile -strategy=neovim
+```
+
 Some strategies clear the screen before executing the test command, but you can
 disable that by setting `g:test#preserve_screen`:
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Currently the following testing frameworks are supported:
 * Fully customized CLI options configuration
 * Extendable with new runners and strategies
 
-Internally test.vim consists of a thoughtfully designed core, and test runners
-are simply plugged in, so that they all work in the same unified way.
+Test.vim consists of a core which provides an abstraction over running any kind
+of tests from the command-line. Concrete test runners are then simply plugged
+in, so they all work in the same unified way.
 
 ## Setup
 
@@ -60,9 +61,8 @@ nmap <silent> <leader>g :TestVisit<CR>
 
 ## Strategies
 
-You can instruct test.vim to run your tests with different strategies (with
-synchronous or asynchronous execution). To use a specific strategy, assign
-it like this:
+Test.vim can run tests using different execution environments called
+"strategies". To use a specific strategy, assign it to a variable:
 
 ```vim
 " make test commands execute using dispatch.vim
@@ -89,7 +89,7 @@ In addition to setting a strategy globally, you can also set one per command:
 ```
 
 Some strategies clear the screen before executing the test command, but you can
-disable that by setting `g:test#preserve_screen`:
+disable this:
 
 ```vim
 let g:test#preserve_screen = 1
@@ -100,7 +100,7 @@ let g:test#preserve_screen = 1
 Strategy is a function which takes one argument – the shell command for the
 test being run – and it is expected to run that command in some way. Test.vim
 comes with many predefined strategies (see above), but if none of them suit
-your needs, you can define your own custom strategy like this:
+your needs, you can define your own custom strategy:
 
 ```vim
 function! EchoStrategy(cmd)

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -18,7 +18,7 @@ function! test#run(type, arguments) abort
 
   let args = test#base#build_position(runner, a:type, position)
   let args = a:arguments + args
-  let args = [test#base#options(runner, a:type)] + args
+  let args = test#base#options(runner, a:type) + args
 
   call test#execute(runner, args)
 endfunction
@@ -46,7 +46,7 @@ endfunction
 
 function! test#execute(runner, args) abort
   let args = a:args
-  let args = [test#base#options(a:runner)] + args
+  let args = test#base#options(a:runner) + args
   call filter(args, '!empty(v:val)')
 
   let executable = test#base#executable(a:runner)

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -9,9 +9,11 @@ endfunction
 function! test#base#options(runner, ...) abort
   let options = get(g:, 'test#'.a:runner.'#options')
   if empty(a:000) && type(options) == type('')
-    return options
+    return split(options)
   elseif !empty(a:000) && type(options) == type({})
-    return get(options, a:000[0])
+    return split(get(options, a:000[0], ''))
+  else
+    return []
   endif
 endfunction
 

--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -26,7 +26,6 @@ endfunction
 function! test#java#maventest#build_args(args) abort
   let args = ['-Dtest='] + a:args
   return [join(args, "")]
-
 endfunction
 
 function! test#java#maventest#executable() abort

--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -1,4 +1,11 @@
 let test#javascript#patterns = {
-  \ 'test':      ['\v^\s*it[( ]%("|'')(.*)%("|''),'],
-  \ 'namespace': ['\v^\s*%(describe|context)[( ]%("|'')(.*)%("|''),'],
+  \ 'test': [
+    \ '\v^\s*%(%(bdd\.)?it|%(tdd\.)?test)\s*[( ]\s*%("|'')(.*)%("|'')\s*,',
+    \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*function\s*[(]'
+  \],
+  \ 'namespace': [
+    \'\v^\s*%(%(bdd\.)?describe|%(tdd\.)?suite|context)\s*[( ]\s*%("|'')(.*)%("|'')\s*,',
+    \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*[{]',
+    \ '\v^\s*registerSuite\s*[(]\s*[{]\s*name\s*:\s*%("|'')(.*)%("|'')\s*,'
+  \],
 \}

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -1,0 +1,55 @@
+if !exists('g:test#javascript#intern#file_pattern')
+  let g:test#javascript#intern#file_pattern = '\vtests?/.*\.js$'
+endif
+
+if !exists('g:test#javascript#intern#test_runner')
+  let g:test#javascript#intern#test_runner = 'intern-client'
+endif
+
+if !exists('g:test#javascript#intern#config_module')
+  let g:test#javascript#intern#config_module = 'tests/intern'
+endif
+
+function! test#javascript#intern#test_file(file) abort
+  return a:file =~# g:test#javascript#intern#file_pattern
+       \ && filereadable(g:test#javascript#intern#config_module . '.js')
+endfunction
+
+function! test#javascript#intern#build_position(type, position) abort
+  let filename = fnamemodify(a:position['file'], ':r')
+  if  filename =~# '\vtests?/functional/.*$'
+    let suite = 'functionalSuites=' . filename
+  else
+    let suite = 'suites=' . filename
+  endif
+
+  if a:type == 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      return [suite, 'grep=' . shellescape(name, 1)]
+    else
+      return [suite]
+    endif
+  elseif a:type == 'file'
+    return [suite]
+  else
+    return []
+endfunction
+
+function! test#javascript#intern#build_args(args) abort
+  let config = 'config=' . g:test#javascript#intern#config_module
+  return [config] + a:args
+endfunction
+
+function! test#javascript#intern#executable() abort
+  if filereadable('node_modules/.bin/' . g:test#javascript#intern#test_runner)
+    return 'node_modules/.bin/'. g:test#javascript#intern#test_runner
+  else
+    return g:test#javascript#intern#test_runner
+  endif
+endfunction
+
+function! s:nearest_test(position)
+  let name = test#base#nearest_test(a:position, g:test#javascript#patterns)
+  return join(name['namespace'] + name['test'], ' - ')
+endfunction

--- a/autoload/test/php.vim
+++ b/autoload/test/php.vim
@@ -1,4 +1,4 @@
 let test#php#patterns = {
-  \ 'test':      ['\v^\s*function (test\w+)'],
-  \ 'namespace': ['\v^\s*class (\w+)'],
+  \ 'test':      ['\v^\s*public function (\w*)\('],
+  \ 'namespace': [],
 \}

--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -39,11 +39,6 @@ function! test#php#phpunit#executable() abort
 endfunction
 
 function! s:nearest_test(position)
-  let patterns = {
-    \ 'test': [
-    \    '\vpublic function (\w*)\('],
-    \ 'namespace': []
-    \}
-  let name = test#base#nearest_test(a:position, patterns)
+  let name = test#base#nearest_test(a:position, g:test#php#patterns)
   return join(name['test'])
 endfunction

--- a/autoload/test/ruby/minitest.vim
+++ b/autoload/test/ruby/minitest.vim
@@ -42,7 +42,7 @@ function! test#ruby#minitest#build_args(args) abort
     endif
   endfor
 
-  let kind = matchstr(test#ruby#minitest#executable(), 'ruby\|rake')
+  let kind = matchstr(test#base#executable('ruby#minitest'), 'ruby\|rake')
   return s:build_{kind}_args(get(l:, 'path'), a:args)
 endfunction
 

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -206,16 +206,26 @@ CUSTOM STRATEGIES                               *test-custom-strategies*
 Strategy is a function which takes a test command and executes it in some way.
 If none of the built-in strategies suit your needs, you can define your own:
 >
-  function! MyStrategy(cmd)
+  function! EchoStrategy(cmd)
     echo 'It works! Command for running tests: ' . a:cmd
   endfunction
 
-  let g:test#custom_strategies = {'my_strategy': function('MyStrategy')}
+  let g:test#custom_strategies = {'echo': function('EchoStrategy')}
+  let g:test#strategy = 'echo'
 <
-Key in this dictionary is a name of the strategy, value is a |Funcref|.
-Then you can choose your custom strategy just like any other:
+
+TRANSFORMATIONS                                 *test-transformations*
+
+You can automatically apply transformations of your test commands by
+registering a "transformation" function:
 >
-  let g:test#strategy = 'my_strategy'
+  function! VagrantTransform(cmd) abort
+    let vagrant_project = get(matchlist(s:cat('Vagrantfile'), '\vconfig\.vm.synced_folder ["''].+[''"], ["''](.+)[''"]'), 1)
+    return 'vagrant ssh --command '.shellescape('cd '.vagrant_project.'; '.a:cmd)
+  endfunction
+
+  let g:test#custom_transformations = {'vagrant': function('VagrantTransform')}
+  let g:test#transformation = 'vagrant'
 <
 
 CONFIGURATION                                   *test-configuration*

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -203,26 +203,31 @@ isn't that nice).
 <
 CUSTOM STRATEGIES                               *test-custom-strategies*
 
-Strategy is a function with command for running tests as argument.
-If you want to define your own strategy - simple define new function, like this:
+Strategy is a function which takes a test command and executes it in some way.
+If none of the built-in strategies suit your needs, you can define your own:
 >
   function! MyStrategy(cmd)
     echo 'It works! Command for running tests: ' . a:cmd
   endfunction
-<
-Then add this function to vim-test custom strategies |dict|:
->
+
   let g:test#custom_strategies = {'my_strategy': function('MyStrategy')}
 <
-Key in this dict is a name of the strategy, value is a |Funcref|.
-Choose your custom strategy:
+Key in this dictionary is a name of the strategy, value is a |Funcref|.
+Then you can choose your custom strategy just like any other:
 >
   let g:test#strategy = 'my_strategy'
 <
-Refer to vim-test/autoload/test/strategy.vim for examples of default strategies.
 
 CONFIGURATION                                   *test-configuration*
 
+In addition to setting a strategy globally, you can also set one per command:
+>
+  :TestFile -strategy=neovim
+<
+If you want to disable clearing the screen for strategies, you can do
+>
+  let g:test#preserve_screen = 1
+<
 You may find yourself specifying certain options for your test runners in
 certain situations. You can configure your prefered options with
 >
@@ -239,10 +244,6 @@ Or, if you prefer more granular approach, you can do
 If you want to manually configure a test runner's executable, you can do
 >
   let g:test#ruby#rspec#executable = 'foreman run rspec'
-<
-If you want to disable clearing the screen for some strategies, you can do
->
-  let g:test#preserve_screen = 1
 <
 You can instruct test.vim to generate absolute file paths:
 >

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -14,7 +14,7 @@ endfunction
 let g:test#runners = get(g:, 'test#runners', {})
 call s:extend(g:test#runners, {
   \ 'Ruby':       ['Minitest', 'RSpec', 'Cucumber'],
-  \ 'JavaScript': ['Mocha', 'Jasmine'],
+  \ 'JavaScript': ['Intern', 'Mocha', 'Jasmine'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'Nose'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Go':         ['GoTest'],

--- a/spec/fixtures/intern/outside.js
+++ b/spec/fixtures/intern/outside.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/bdd.js
+++ b/spec/fixtures/intern/tests/bdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/functional/bdd.js
+++ b/spec/fixtures/intern/tests/functional/bdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/functional/object.js
+++ b/spec/fixtures/intern/tests/functional/object.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  var registerSuite = require('intern!object');
+  var assert = require('intern/chai!assert');
+
+  registerSuite({name: 'Math',
+
+    'adds two numbers': function () {
+      assert.equal(4 + 2, 6);
+    },
+
+    'subtracts two numbers': function () {
+      assert.equal(4 - 2, 2);
+    },
+
+    'Extra Math': {
+
+      'multiplies two numbers': function () {
+        assert.equal(4 * 2, 8);
+      },
+
+      'divides two numbers': function () {
+        assert.equal(4 / 2, 2);
+      }
+
+    }
+
+  });
+});

--- a/spec/fixtures/intern/tests/functional/tdd.js
+++ b/spec/fixtures/intern/tests/functional/tdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var tdd = require('intern!tdd');
+  var assert = require('intern/chai!assert');
+
+  tdd.suite('Math', function () {
+    tdd.test('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    tdd.test('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    tdd.suite('Extra Math', function () {
+      tdd.test('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      tdd.test('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/intern.js
+++ b/spec/fixtures/intern/tests/intern.js
@@ -1,0 +1,20 @@
+define({
+  capabilities: {
+  },
+  reporters: [
+    'Console'
+  ],
+  environments: [
+  ],
+  maxConcurrency: 1,
+  loaderOptions: {
+    packages: []
+  },
+  suites: [
+    'tests/unit/*'
+  ],
+  functionalSuites: [
+    'tests/functional/*'
+  ],
+  excludeInstrumentation: /^(?:tests|node_modules)\//
+});

--- a/spec/fixtures/intern/tests/object.js
+++ b/spec/fixtures/intern/tests/object.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  var registerSuite = require('intern!object');
+  var assert = require('intern/chai!assert');
+
+  registerSuite({name: 'Math',
+
+    'adds two numbers': function () {
+      assert.equal(4 + 2, 6);
+    },
+
+    'subtracts two numbers': function () {
+      assert.equal(4 - 2, 2);
+    },
+
+    'Extra Math': {
+
+      'multiplies two numbers': function () {
+        assert.equal(4 * 2, 8);
+      },
+
+      'divides two numbers': function () {
+        assert.equal(4 / 2, 2);
+      }
+
+    }
+
+  });
+});

--- a/spec/fixtures/intern/tests/tdd.js
+++ b/spec/fixtures/intern/tests/tdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var tdd = require('intern!tdd');
+  var assert = require('intern/chai!assert');
+
+  tdd.suite('Math', function () {
+    tdd.test('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    tdd.test('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    tdd.suite('Extra Math', function () {
+      tdd.test('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      tdd.test('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/unit/bdd.js
+++ b/spec/fixtures/intern/tests/unit/bdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/unit/object.js
+++ b/spec/fixtures/intern/tests/unit/object.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  var registerSuite = require('intern!object');
+  var assert = require('intern/chai!assert');
+
+  registerSuite({name: 'Math',
+
+    'adds two numbers': function () {
+      assert.equal(4 + 2, 6);
+    },
+
+    'subtracts two numbers': function () {
+      assert.equal(4 - 2, 2);
+    },
+
+    'Extra Math': {
+
+      'multiplies two numbers': function () {
+        assert.equal(4 * 2, 8);
+      },
+
+      'divides two numbers': function () {
+        assert.equal(4 / 2, 2);
+      }
+
+    }
+
+  });
+});

--- a/spec/fixtures/intern/tests/unit/tdd.js
+++ b/spec/fixtures/intern/tests/unit/tdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var tdd = require('intern!tdd');
+  var assert = require('intern/chai!assert');
+
+  tdd.suite('Math', function () {
+    tdd.test('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    tdd.test('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    tdd.suite('Extra Math', function () {
+      tdd.test('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      tdd.test('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/intern_spec.vim
+++ b/spec/intern_spec.vim
@@ -1,0 +1,217 @@
+source spec/helpers.vim
+
+describe "Intern"
+
+  before
+    cd spec/fixtures/intern
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  context "BDD interface"
+    it "runs nearest test"
+      view +6 tests/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''Math - adds two numbers'''
+
+      view +15 tests/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/unit/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''Math - adds two numbers'''
+
+      view +15 tests/unit/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/functional/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''Math - adds two numbers'''
+
+      view +15 tests/functional/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''Math - Extra Math - multiplies two numbers'''
+    end
+
+    it "runs file tests"
+      view tests/bdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd'
+
+      view tests/unit/bdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd'
+
+      view tests/functional/bdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd'
+    end
+
+    it "runs test suites"
+      view tests/bdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/unit/bdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/functional/bdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+
+  context "TDD interface"
+    it "runs nearest test"
+      view +6 tests/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''Math - adds two numbers'''
+
+      view +15 tests/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/unit/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''Math - adds two numbers'''
+
+      view +15 tests/unit/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/functional/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''Math - adds two numbers'''
+
+      view +15 tests/functional/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''Math - Extra Math - multiplies two numbers'''
+    end
+
+    it "runs file tests"
+      view tests/tdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd'
+
+      view tests/unit/tdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd'
+
+      view tests/functional/tdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd'
+    end
+
+    it "runs test suites"
+      view tests/tdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/unit/tdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/functional/tdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+
+  context "Object interface"
+    it "runs nearest test"
+      view +7 tests/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''Math - adds two numbers'''
+
+      view +17 tests/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +7 tests/unit/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''Math - adds two numbers'''
+
+      view +17 tests/unit/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +7 tests/functional/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''Math - adds two numbers'''
+
+      view +17 tests/functional/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''Math - Extra Math - multiplies two numbers'''
+    end
+
+    it "runs file tests"
+      view tests/object.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object'
+
+      view tests/unit/object.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object'
+
+      view tests/functional/object.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object'
+    end
+
+    it "runs test suites"
+      view tests/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/unit/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/functional/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+end

--- a/spec/main_spec.vim
+++ b/spec/main_spec.vim
@@ -76,5 +76,4 @@ describe 'Main'
 
     unlet g:test#filename_modifier
   end
-
 end


### PR DESCRIPTION
This pull request adds Intern support (#105) with the following features:
- Supports BDD/TDD/Object interfaces.
- Supports both unit and functional tests.
- Supports `TestNearest`, `TestFile`, and `TestSuite`.
- Allows specifying Intern's test runner (`intern-client` vs `intern-runner`) through `g:test#javascript#intern#test_runner`.
- Allows specifying Intern's configuration module (`tests/intern`) through `g:test#javascript#intern#config_module`.

Things to note:
- It is impossible to implicitly detect which test runner to use. Therefore, the default is `intern-client`. However, the user can change it through `g:test#javascript#intern#test_runner` to `intern-runner`.
- It is impossible to implicitly detect whether the test is a unit test or a functional test without assumptions. Intern recommends using the file structure `tests/unit/*` and `tests/functional/*` to separate the two. Therefore, this recommendation was used to differentiate between the two implicitly. Anything under `test/functional/*` is considered functional test, and anything else is considered regular unit test.
- Even though Intern recommends sticking with the file `tests/intern` as the default config module, the users can still choose any other file as the config module. Therefore, the user must set  `g:test#javascript#intern#config_module` appropriately if they choose to use anything other than the default `tests/intern`.
- ~~Even though I wrote the test cases in `spec/`, I couldn't manage to run it as I couldn't setup `vim-flavour` successfully. I did however test everything manually.~~ It actually passed the tests :)