### PR TITLE
Add support for JavaScript's Intern framework (#2)

### DIFF
--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -1,4 +1,11 @@
 let test#javascript#patterns = {
-  \ 'test':      ['\v^\s*it[( ]%("|'')(.*)%("|''),'],
-  \ 'namespace': ['\v^\s*%(describe|context)[( ]%("|'')(.*)%("|''),'],
+  \ 'test': [
+    \ '\v^\s*%(%(bdd\.)?it|%(tdd\.)?test)\s*[( ]\s*%("|'')(.*)%("|'')\s*,',
+    \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*function\s*[(]'
+  \],
+  \ 'namespace': [
+    \'\v^\s*%(%(bdd\.)?describe|%(tdd\.)?suite|context)\s*[( ]\s*%("|'')(.*)%("|'')\s*,',
+    \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*[{]',
+    \ '\v^\s*registerSuite\s*[(]\s*[{]\s*name\s*:\s*%("|'')(.*)%("|'')\s*,'
+  \],
 \}

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -1,0 +1,55 @@
+if !exists('g:test#javascript#intern#file_pattern')
+  let g:test#javascript#intern#file_pattern = '\vtests?/.*\.js$'
+endif
+
+if !exists('g:test#javascript#intern#test_runner')
+  let g:test#javascript#intern#test_runner = 'intern-client'
+endif
+
+if !exists('g:test#javascript#intern#config_module')
+  let g:test#javascript#intern#config_module = 'tests/intern'
+endif
+
+function! test#javascript#intern#test_file(file) abort
+  return a:file =~# g:test#javascript#intern#file_pattern
+       \ && filereadable(g:test#javascript#intern#config_module . '.js')
+endfunction
+
+function! test#javascript#intern#build_position(type, position) abort
+  let filename = fnamemodify(a:position['file'], ':r')
+  if  filename =~# '\vtests?/functional/.*$'
+    let suite = 'functionalSuites=' . filename
+  else
+    let suite = 'suites=' . filename
+  endif
+
+  if a:type == 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      return [suite, 'grep=' . shellescape(name, 1)]
+    else
+      return [suite]
+    endif
+  elseif a:type == 'file'
+    return [suite]
+  else
+    return []
+endfunction
+
+function! test#javascript#intern#build_args(args) abort
+  let config = 'config=' . g:test#javascript#intern#config_module
+  return [config] + a:args
+endfunction
+
+function! test#javascript#intern#executable() abort
+  if filereadable('node_modules/.bin/' . g:test#javascript#intern#test_runner)
+    return 'node_modules/.bin/'. g:test#javascript#intern#test_runner
+  else
+    return g:test#javascript#intern#test_runner
+  endif
+endfunction
+
+function! s:nearest_test(position)
+  let name = test#base#nearest_test(a:position, g:test#javascript#patterns)
+  return join(name['namespace'] + name['test'], ' - ')
+endfunction

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -14,7 +14,7 @@ endfunction
 let g:test#runners = get(g:, 'test#runners', {})
 call s:extend(g:test#runners, {
   \ 'Ruby':       ['Minitest', 'RSpec', 'Cucumber'],
-  \ 'JavaScript': ['Mocha', 'Jasmine'],
+  \ 'JavaScript': ['Intern', 'Mocha', 'Jasmine'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'Nose'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Go':         ['GoTest'],

--- a/spec/fixtures/intern/outside.js
+++ b/spec/fixtures/intern/outside.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/bdd.js
+++ b/spec/fixtures/intern/tests/bdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/functional/bdd.js
+++ b/spec/fixtures/intern/tests/functional/bdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/functional/object.js
+++ b/spec/fixtures/intern/tests/functional/object.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  var registerSuite = require('intern!object');
+  var assert = require('intern/chai!assert');
+
+  registerSuite({name: 'Math',
+
+    'adds two numbers': function () {
+      assert.equal(4 + 2, 6);
+    },
+
+    'subtracts two numbers': function () {
+      assert.equal(4 - 2, 2);
+    },
+
+    'Extra Math': {
+
+      'multiplies two numbers': function () {
+        assert.equal(4 * 2, 8);
+      },
+
+      'divides two numbers': function () {
+        assert.equal(4 / 2, 2);
+      }
+
+    }
+
+  });
+});

--- a/spec/fixtures/intern/tests/functional/tdd.js
+++ b/spec/fixtures/intern/tests/functional/tdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var tdd = require('intern!tdd');
+  var assert = require('intern/chai!assert');
+
+  tdd.suite('Math', function () {
+    tdd.test('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    tdd.test('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    tdd.suite('Extra Math', function () {
+      tdd.test('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      tdd.test('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/intern.js
+++ b/spec/fixtures/intern/tests/intern.js
@@ -1,0 +1,20 @@
+define({
+  capabilities: {
+  },
+  reporters: [
+    'Console'
+  ],
+  environments: [
+  ],
+  maxConcurrency: 1,
+  loaderOptions: {
+    packages: []
+  },
+  suites: [
+    'tests/unit/*'
+  ],
+  functionalSuites: [
+    'tests/functional/*'
+  ],
+  excludeInstrumentation: /^(?:tests|node_modules)\//
+});

--- a/spec/fixtures/intern/tests/object.js
+++ b/spec/fixtures/intern/tests/object.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  var registerSuite = require('intern!object');
+  var assert = require('intern/chai!assert');
+
+  registerSuite({name: 'Math',
+
+    'adds two numbers': function () {
+      assert.equal(4 + 2, 6);
+    },
+
+    'subtracts two numbers': function () {
+      assert.equal(4 - 2, 2);
+    },
+
+    'Extra Math': {
+
+      'multiplies two numbers': function () {
+        assert.equal(4 * 2, 8);
+      },
+
+      'divides two numbers': function () {
+        assert.equal(4 / 2, 2);
+      }
+
+    }
+
+  });
+});

--- a/spec/fixtures/intern/tests/tdd.js
+++ b/spec/fixtures/intern/tests/tdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var tdd = require('intern!tdd');
+  var assert = require('intern/chai!assert');
+
+  tdd.suite('Math', function () {
+    tdd.test('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    tdd.test('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    tdd.suite('Extra Math', function () {
+      tdd.test('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      tdd.test('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/unit/bdd.js
+++ b/spec/fixtures/intern/tests/unit/bdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var bdd = require('intern!bdd');
+  var assert = require('intern/chai!assert');
+
+  bdd.describe('Math', function () {
+    bdd.it('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    bdd.it('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    bdd.describe('Extra Math', function () {
+      bdd.it('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      bdd.it('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/fixtures/intern/tests/unit/object.js
+++ b/spec/fixtures/intern/tests/unit/object.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  var registerSuite = require('intern!object');
+  var assert = require('intern/chai!assert');
+
+  registerSuite({name: 'Math',
+
+    'adds two numbers': function () {
+      assert.equal(4 + 2, 6);
+    },
+
+    'subtracts two numbers': function () {
+      assert.equal(4 - 2, 2);
+    },
+
+    'Extra Math': {
+
+      'multiplies two numbers': function () {
+        assert.equal(4 * 2, 8);
+      },
+
+      'divides two numbers': function () {
+        assert.equal(4 / 2, 2);
+      }
+
+    }
+
+  });
+});

--- a/spec/fixtures/intern/tests/unit/tdd.js
+++ b/spec/fixtures/intern/tests/unit/tdd.js
@@ -1,0 +1,24 @@
+define(function (require) {
+  var tdd = require('intern!tdd');
+  var assert = require('intern/chai!assert');
+
+  tdd.suite('Math', function () {
+    tdd.test('adds two numbers', function () {
+      assert.equal(4 + 2, 6);
+    });
+
+    tdd.test('subtracts two numbers', function () {
+      assert.equal(4 - 2, 2);
+    });
+
+    tdd.suite('Extra Math', function () {
+      tdd.test('multiplies two numbers', function () {
+        assert.equal(4 * 2, 8);
+      });
+
+      tdd.test('divides two numbers', function () {
+        assert.equal(4 / 2, 2);
+      });
+    });
+  });
+});

--- a/spec/intern_spec.vim
+++ b/spec/intern_spec.vim
@@ -1,0 +1,217 @@
+source spec/helpers.vim
+
+describe "Intern"
+
+  before
+    cd spec/fixtures/intern
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  context "BDD interface"
+    it "runs nearest test"
+      view +6 tests/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''Math - adds two numbers'''
+
+      view +15 tests/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/unit/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''Math - adds two numbers'''
+
+      view +15 tests/unit/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/functional/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''Math - adds two numbers'''
+
+      view +15 tests/functional/bdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''Math - Extra Math - multiplies two numbers'''
+    end
+
+    it "runs file tests"
+      view tests/bdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd'
+
+      view tests/unit/bdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd'
+
+      view tests/functional/bdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd'
+    end
+
+    it "runs test suites"
+      view tests/bdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/unit/bdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/functional/bdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+
+  context "TDD interface"
+    it "runs nearest test"
+      view +6 tests/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''Math - adds two numbers'''
+
+      view +15 tests/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/unit/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''Math - adds two numbers'''
+
+      view +15 tests/unit/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +6 tests/functional/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''Math - adds two numbers'''
+
+      view +15 tests/functional/tdd.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''Math - Extra Math - multiplies two numbers'''
+    end
+
+    it "runs file tests"
+      view tests/tdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd'
+
+      view tests/unit/tdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd'
+
+      view tests/functional/tdd.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd'
+    end
+
+    it "runs test suites"
+      view tests/tdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/unit/tdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/functional/tdd.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+
+  context "Object interface"
+    it "runs nearest test"
+      view +7 tests/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''Math - adds two numbers'''
+
+      view +17 tests/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +7 tests/unit/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''Math - adds two numbers'''
+
+      view +17 tests/unit/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''Math - Extra Math - multiplies two numbers'''
+
+      view +7 tests/functional/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''Math - adds two numbers'''
+
+      view +17 tests/functional/object.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''Math - Extra Math - multiplies two numbers'''
+    end
+
+    it "runs file tests"
+      view tests/object.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object'
+
+      view tests/unit/object.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object'
+
+      view tests/functional/object.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object'
+    end
+
+    it "runs test suites"
+      view tests/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/unit/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+
+      view tests/functional/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds Intern support (#105) with the following features:
- Supports BDD/TDD/Object interfaces.
- Supports both unit and functional tests.
- Supports `TestNearest`, `TestFile`, and `TestSuite`.
- Allows specifying Intern's test runner (`intern-client` vs `intern-runner`) through `g:test#javascript#intern#test_runner`.
- Allows specifying Intern's configuration module (`tests/intern`) through `g:test#javascript#intern#config_module`.

Things to note:
- It is impossible to implicitly detect which test runner to use. Therefore, the default is `intern-client`. However, the user can change it through `g:test#javascript#intern#test_runner` to `intern-runner`.
- It is impossible to implicitly detect whether the test is a unit test or a functional test without assumptions. Intern recommends using the file structure `tests/unit/*` and `tests/functional/*` to separate the two. Therefore, this recommendation was used to differentiate between the two implicitly. Anything under `test/functional/*` is considered functional test, and anything else is considered regular unit test.
- Even though Intern recommends sticking with the file `tests/intern` as the default config module, the users can still choose any other file as the config module. Therefore, the user must set  `g:test#javascript#intern#config_module` appropriately if they choose to use anything other than the default `tests/intern`.