### PR TITLE
CD into CWD before executing a runner in external terminals

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -54,12 +54,13 @@ endfunction
 
 function! s:pretty_command(cmd) abort
   let clear = !s:Windows() ? 'clear' : 'cls'
+  let cd = 'cd ' . shellescape(getcwd())
   let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
 
   if !exists('g:test#preserve_screen') || !g:test#preserve_screen
-    return join([l:clear, l:echo, a:cmd], '; ')
+    return join([l:clear, l:cd, l:echo, a:cmd], '; ')
   else
-    return join([l:echo, a:cmd], '; ')
+    return join([l:cd, l:echo, a:cmd], '; ')
   endif
 endfunction
 


### PR DESCRIPTION
Currently, the external terminal need to be CDed into Vim's CWD manually for the test runner to execute successfully. This tiny PR automatically CD into Vim's CWD before executing any test runner in external terminals. Test with Terminal.app successfully, and should work with other terminals.