### PR TITLE
Add support for Intern's QUnit interface and improve nearest test regex

### DIFF
--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -1,11 +1,4 @@
 let test#javascript#patterns = {
-  \ 'test': [
-    \ '\v^\s*%(%(bdd\.)?it|%(tdd\.)?test)\s*[( ]\s*%("|'')(.*)%("|'')\s*,',
-    \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*function\s*[(]'
-  \],
-  \ 'namespace': [
-    \'\v^\s*%(%(bdd\.)?describe|%(tdd\.)?suite|context)\s*[( ]\s*%("|'')(.*)%("|'')\s*,',
-    \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*[{]',
-    \ '\v^\s*registerSuite\s*[(]\s*[{]\s*name\s*:\s*%("|'')(.*)%("|'')\s*,'
-  \],
+  \ 'test': ['\v^\s*%(it|test)\s*[( ]\s*%("|'')(.*)%("|'')'],
+  \ 'namespace': ['\v^\s*%(describe|suite|context)\s*[( ]\s*%("|'')(.*)%("|'')'],
 \}

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -50,6 +50,21 @@ function! test#javascript#intern#executable() abort
 endfunction
 
 function! s:nearest_test(position)
-  let name = test#base#nearest_test(a:position, g:test#javascript#patterns)
-  return join(name['namespace'] + name['test'], ' - ')
+  let patterns = {
+    \ 'test': [
+      \ '\v^\s*%(%(bdd\.)?it|%(tdd\.|QUnit\.)?test)\s*[( ]\s*%("|'')(.*)%("|'')',
+      \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*function\s*[(]'
+    \] + g:test#javascript#patterns['test'],
+    \ 'namespace': [
+      \'\v^\s*%(%(bdd\.)?describe|%(tdd\.)?suite|%(QUnit\.)?module)\s*[( ]\s*%("|'')(.*)%("|'')',
+      \ '\v^\s*registerSuite\s*[(]\s*[{]\s*name\s*:\s*%("|'')(.*)%("|'')',
+      \ '\v^\s*%("|'')(.*)%("|'')\s*:\s*[{]'
+    \] + g:test#javascript#patterns['namespace'],
+  \}
+
+  let name = test#base#nearest_test(a:position, l:patterns)
+
+  return (len(name['namespace']) ? '^' : '') . 
+       \ test#base#escape_regex(join(name['namespace'] + name['test'], ' - ')) .
+       \ (len(name['test']) ? '$' : ' - ')
 endfunction

--- a/spec/fixtures/intern/tests/qunit.js
+++ b/spec/fixtures/intern/tests/qunit.js
@@ -1,0 +1,19 @@
+define(function (require) {
+  var QUnit = require('intern!qunit');
+
+  QUnit.module('Math');
+  QUnit.test('adds two numbers', function (assert) {
+    assert.equal(4 + 2, 6);
+  });
+  QUnit.test('subtracts two numbers', function (assert) {
+    assert.equal(4 - 2, 2);
+  });
+
+  QUnit.module('Extra Math');
+  QUnit.test('multiplies two numbers', function (assert) {
+    assert.equal(4 * 2, 8);
+  });
+  QUnit.test('divides two numbers', function (assert) {
+    assert.equal(4 / 2, 2);
+  });
+});

--- a/spec/intern_spec.vim
+++ b/spec/intern_spec.vim
@@ -16,32 +16,32 @@ describe "Intern"
       view +6 tests/bdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''^Math - adds two numbers$'''
 
       view +15 tests/bdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''^Math - Extra Math - multiplies two numbers$'''
 
-      view +6 tests/unit/bdd.js
+      view +5 tests/bdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''^Math - '''
 
-      view +15 tests/unit/bdd.js
+      view +14 tests/bdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/bdd grep=''^Math - Extra Math - '''
 
-      view +6 tests/functional/bdd.js
+      view +11 tests/unit/bdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/bdd grep=''^Math - subtracts two numbers$'''
 
-      view +15 tests/functional/bdd.js
+      view +20 tests/functional/bdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/bdd grep=''^Math - Extra Math - divides two numbers$'''
     end
 
     it "runs file tests"
@@ -84,32 +84,32 @@ describe "Intern"
       view +6 tests/tdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''^Math - adds two numbers$'''
 
       view +15 tests/tdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''^Math - Extra Math - multiplies two numbers$'''
 
-      view +6 tests/unit/tdd.js
+      view +5 tests/tdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''^Math - '''
 
-      view +15 tests/unit/tdd.js
+      view +14 tests/tdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/tdd grep=''^Math - Extra Math - '''
 
-      view +6 tests/functional/tdd.js
+      view +11 tests/unit/tdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/tdd grep=''^Math - subtracts two numbers$'''
 
-      view +15 tests/functional/tdd.js
+      view +20 tests/functional/tdd.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/tdd grep=''^Math - Extra Math - divides two numbers$'''
     end
 
     it "runs file tests"
@@ -152,32 +152,32 @@ describe "Intern"
       view +7 tests/object.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''^Math - adds two numbers$'''
 
       view +17 tests/object.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''^Math - Extra Math - multiplies two numbers$'''
 
-      view +7 tests/unit/object.js
+      view +5 tests/object.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''^Math - '''
 
-      view +17 tests/unit/object.js
+      view +15 tests/object.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/object grep=''^Math - Extra Math - '''
 
-      view +7 tests/functional/object.js
+      view +12 tests/unit/object.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''Math - adds two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/unit/object grep=''^Math - subtracts two numbers$'''
 
-      view +17 tests/functional/object.js
+      view +22 tests/functional/object.js
       TestNearest
 
-      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''Math - Extra Math - multiplies two numbers'''
+      Expect g:test#last_command == 'intern-client config=tests/intern functionalSuites=tests/functional/object grep=''^Math - Extra Math - divides two numbers$'''
     end
 
     it "runs file tests"
@@ -209,6 +209,44 @@ describe "Intern"
       Expect g:test#last_command == 'intern-client config=tests/intern'
 
       view tests/functional/object.js
+      TestSuite
+
+      Expect g:test#last_command == 'intern-client config=tests/intern'
+    end
+  end
+
+  context "QUnit interface"
+    it "runs nearest test"
+      view +5 tests/qunit.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/qunit grep=''adds two numbers$'''
+
+      view +13 tests/qunit.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/qunit grep=''multiplies two numbers$'''
+
+      view +4 tests/qunit.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/qunit grep=''^Math - '''
+
+      view +12 tests/qunit.js
+      TestNearest
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/qunit grep=''^Extra Math - '''
+    end
+
+    it "runs file tests"
+      view tests/qunit.js
+      TestFile
+
+      Expect g:test#last_command == 'intern-client config=tests/intern suites=tests/qunit'
+    end
+
+    it "runs test suites"
+      view tests/qunit.js
       TestSuite
 
       Expect g:test#last_command == 'intern-client config=tests/intern'


### PR DESCRIPTION
**Improvements:**
- Add support for Intern's QUnit interface.
- Move Intern's namespace and test pattern away from `javascript.vim` to `intern.vim`. Some of the patterns are specific to Intern, and should not be globalized for other javascript test frameworks. Since Intern can support other testing interfaces, the default javascript patterns were added as well.
- Improve `TestNearest` regex polyfill (#110). If the nearest test detected is:
  - Namespace(s) only, then `^` will be prefixed only. This allows running anything starting with the namespace(s) pattern only (all sub-namespaces and sub-tests).
  - Test inside namespace(s), then `^` will be prefixed, and `$` will be postfixed. This allows running anything exactly matching the test pattern inside the namespace(s).
  - Test without any suite, then `$` will be postfixed only (QUnit only, see limitation). This allows running test(s) ending with the test pattern.

**QUnit Limitation:**
QUnit grouping of tests under namespaces/module is weird. It takes a linear approach similar to this:
```javascript
QUnit.module('Suite #1');
QUnit.test('Part of Suite #1', ...);
...
QUnit.module('Suite #2');
QUnit.test('Part of Suite #2', ...);
...
```
Since vim-test scans the scopes incrementally for test then namespace(s), if the cursor is near a test, then that test will be detected, but the namespace/module will not be detected. This is due to the fact that both of them are on the same scope. This is why I decided to postfix with `$` (without `^`), if only a test was detected (without namespaces). QUnit is the only interface suffering from such limitation, and all other interfaces will function properly.

QUnit has an alternative way of using scoped namespace(s)/module(s), but it is not supported by Intern's implementation currently. If it get supported in the future, then there is no need to do any changes on the patterns, as it should detect it correctly since it is scoped.