### PR TITLE
Improve Mocha's TestNearest regex polyfill

### DIFF
--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -10,7 +10,7 @@ function! test#javascript#mocha#build_position(type, position) abort
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      let name = '--grep '.shellescape(test#base#escape_regex(name), 1)
+      let name = '--grep '.shellescape(name, 1)
     endif
     return [a:position['file'], name]
   elseif a:type == 'file'
@@ -41,5 +41,7 @@ endfunction
 
 function! s:nearest_test(position)
   let name = test#base#nearest_test(a:position, g:test#javascript#patterns)
-  return join(name['namespace'] + name['test'])
+  return (len(name['namespace']) ? '^' : '') . 
+       \ test#base#escape_regex(join(name['namespace'] + name['test'])) .
+       \ (len(name['test']) ? '$' : '')
 endfunction

--- a/spec/mocha_spec.vim
+++ b/spec/mocha_spec.vim
@@ -16,68 +16,68 @@ describe "Mocha"
       view +1 test/normal.js
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.js --grep ''Math'''
+      Expect g:test#last_command == 'mocha test/normal.js --grep ''^Math'''
 
       view +2 test/normal.js
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.js --grep ''Math Addition'''
+      Expect g:test#last_command == 'mocha test/normal.js --grep ''^Math Addition'''
 
       view +3 test/normal.js
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.js --grep ''Math Addition adds two numbers'''
+      Expect g:test#last_command == 'mocha test/normal.js --grep ''^Math Addition adds two numbers$'''
     end
 
     it "aliases context to describe"
       view +1 test/context.js
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/context.js --grep ''Math'''
+      Expect g:test#last_command == 'mocha test/context.js --grep ''^Math'''
 
       view +2 test/context.js
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/context.js --grep ''Math Addition'''
+      Expect g:test#last_command == 'mocha test/context.js --grep ''^Math Addition'''
 
       view +3 test/context.js
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/context.js --grep ''Math Addition adds two numbers'''
+      Expect g:test#last_command == 'mocha test/context.js --grep ''^Math Addition adds two numbers$'''
     end
 
     it "runs CoffeeScript"
       view +1 test/normal.coffee
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.coffee --grep ''Math'''
+      Expect g:test#last_command == 'mocha test/normal.coffee --grep ''^Math'''
 
       view +2 test/normal.coffee
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.coffee --grep ''Math Addition'''
+      Expect g:test#last_command == 'mocha test/normal.coffee --grep ''^Math Addition'''
 
       view +3 test/normal.coffee
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.coffee --grep ''Math Addition adds two numbers'''
+      Expect g:test#last_command == 'mocha test/normal.coffee --grep ''^Math Addition adds two numbers$'''
     end
 
     it "runs React"
       view +1 test/normal.jsx
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.jsx --grep ''Math'''
+      Expect g:test#last_command == 'mocha test/normal.jsx --grep ''^Math'''
 
       view +2 test/normal.jsx
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.jsx --grep ''Math Addition'''
+      Expect g:test#last_command == 'mocha test/normal.jsx --grep ''^Math Addition'''
 
       view +3 test/normal.jsx
       TestNearest
 
-      Expect g:test#last_command == 'mocha test/normal.jsx --grep ''Math Addition adds two numbers'''
+      Expect g:test#last_command == 'mocha test/normal.jsx --grep ''^Math Addition adds two numbers$'''
     end
   end
 


### PR DESCRIPTION
Improve Mocha's TestNearest regex polyfill (#110). If the nearest test detected is:
- Namespace(s) only, then `^` will be prefixed only. This allows running anything starting with the namespace(s) pattern only (all sub-namespaces and sub-tests).
- Test inside namespace(s), then `^` will be prefixed, and `$` will be postfixed. This allows running anything exactly matching the test pattern inside the namespace(s).
- Test not inside any namespace, then `$` will be postfixed only. This allows running test(s) ending with the test pattern.
- Nothing, then an empty string will be returned.

I've updated `mocha_spec.vim` to reflect the new changes. I've also tested the new changes with both vim-flavor and mocha installation quickly.
