### PR TITLE
Run Go nearest tests from their directories

### DIFF
--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -7,15 +7,16 @@ function! test#go#gotest#test_file(file) abort
 endfunction
 
 function! test#go#gotest#build_position(type, position) abort
-  if a:type == 'nearest'
-    let name = s:nearest_test(a:position)
-    if !empty(name) | let name = '-run '.shellescape(name, 1).' ./'.expand('%:h') | endif
-    return [name]
-  elseif a:type == 'file'
-    let path = fnamemodify(a:position['file'], ':h')
-    return path != '.' ? ['./' . path . '/...'] : []
-  else
+  if a:type == 'suite'
     return ['./...']
+  else
+    let path = './'.fnamemodify(a:position['file'], ':h')
+
+    if a:type == 'file'
+      return path == './.' ? [] : [path . '/...']
+    elseif a:type == 'nearest'
+      return s:build_nearest_args(a:position, path)
+    endif
   endif
 endfunction
 
@@ -30,4 +31,14 @@ endfunction
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#go#patterns)
   return join(name['test'])
+endfunction
+
+function! s:build_nearest_args(position, path) abort
+  let name = s:nearest_test(a:position)
+
+  if empty(name)
+    return [name]
+  else
+    return ['-run '.shellescape(name.'$', 1).' '.a:path]
+  endif
 endfunction

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -9,7 +9,7 @@ endfunction
 function! test#go#gotest#build_position(type, position) abort
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
-    if !empty(name) | let name = '-run '.shellescape(name, 1) | endif
+    if !empty(name) | let name = '-run '.shellescape(name, 1).' ./'.expand('%:h') | endif
     return [name]
   elseif a:type == 'file'
     let path = fnamemodify(a:position['file'], ':h')

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -15,14 +15,14 @@ describe "GoTest"
     view +5 normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'go test -run ''TestNumbers'' ./.'
+    Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./.'
   end
 
   it "runs nearest tests in subdirectory"
     view +5 mypackage/normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'go test -run ''TestNumbers'' ./mypackage'
+    Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./mypackage'
   end
 
   it "runs file test if nearest test couldn't be found"

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -15,7 +15,14 @@ describe "GoTest"
     view +5 normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'go test -run ''TestNumbers'''
+    Expect g:test#last_command == 'go test -run ''TestNumbers'' ./.'
+  end
+
+  it "runs nearest tests in subdirectory"
+    view +5 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''TestNumbers'' ./mypackage'
   end
 
   it "runs file test if nearest test couldn't be found"


### PR DESCRIPTION
In Go, additional packages can live in subdirectories. In order to run
them properly, the subdirectory needs to be specified.

This fix ensures that the nearest test (by name) is run in the
appropriate directory.