### PR TITLE
Provide filename for Go's TestFile and TestNearest

### DIFF
--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -10,10 +10,10 @@ function! test#go#gotest#build_position(type, position) abort
   if a:type == 'suite'
     return ['./...']
   else
-    let path = './'.fnamemodify(a:position['file'], ':h')
+    let path = fnamemodify(a:position['file'], '.')
 
     if a:type == 'file'
-      return path == './.' ? [] : [path . '/...']
+      return [path]
     elseif a:type == 'nearest'
       let name = s:nearest_test(a:position)
       return empty(name) ? [] : ['-run '.shellescape(name.'$', 1), path]

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -15,14 +15,14 @@ describe "GoTest"
     view +5 normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./.'
+    Expect g:test#last_command == 'go test -run ''TestNumbers$'' normal_test.go'
   end
 
   it "runs nearest tests in subdirectory"
     view +5 mypackage/normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./mypackage'
+    Expect g:test#last_command == 'go test -run ''TestNumbers$'' mypackage/normal_test.go'
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -36,14 +36,14 @@ describe "GoTest"
     view normal_test.go
     TestFile
 
-    Expect g:test#last_command == 'go test'
+    Expect g:test#last_command == 'go test normal_test.go'
   end
 
-  it "runs tests in subdirectory"
+  it "runs file tests in subdirectory"
     view mypackage/normal_test.go
     TestFile
 
-    Expect g:test#last_command == 'go test ./mypackage/...'
+    Expect g:test#last_command == 'go test mypackage/normal_test.go'
   end
 
   it "runs test suites"
@@ -52,5 +52,4 @@ describe "GoTest"
 
     Expect g:test#last_command == 'go test ./...'
   end
-
 end


### PR DESCRIPTION
Providing a filename to the `go test` command ensures that only the
tests in that file are ran. This way if a similar test name exists in
another file (in the same package) it doesn't run.