### PR TITLE
Add basic karma runner

### DIFF
--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -1,0 +1,37 @@
+if !exists('g:test#javascript#karma#file_pattern')
+  let g:test#javascript#karma#file_pattern = '\v^spec/.*spec\.(js|jsx|coffee)$'
+endif
+
+function! test#javascript#karma#test_file(file) abort
+  return a:file =~? g:test#javascript#karma#file_pattern
+endfunction
+
+function! test#javascript#karma#build_position(type, position) abort
+  " There is no easy way to restrict the test files with karma.  Until a way
+  " is found to easily accomplish this, we'll get an empty list here
+  return []
+endfunction
+
+function! test#javascript#karma#build_args(args) abort
+  let args = a:args
+
+  if test#base#no_colors()
+    let args = ['--no-color'] + args
+  endif
+
+  return args
+endfunction
+
+function! test#javascript#karma#executable() abort
+  if filereadable('node_modules/.bin/karma')
+    let karma_exec = 'node_modules/.bin/karma'
+  else
+    let karma_exec = 'karma'
+  endif
+	return karma_exec . ' start --single-run'
+endfunction
+
+function! s:nearest_test(position)
+  let name = test#base#nearest_test(a:position, g:test#javascript#patterns)
+  return join(name['namespace'] + name['test'])
+endfunction

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -14,7 +14,7 @@ endfunction
 let g:test#runners = get(g:, 'test#runners', {})
 call s:extend(g:test#runners, {
   \ 'Ruby':       ['Minitest', 'RSpec', 'Cucumber'],
-  \ 'JavaScript': ['Intern', 'TAP', 'Mocha', 'Jasmine'],
+  \ 'JavaScript': ['Intern', 'TAP', 'Mocha', 'Jasmine', 'Karma'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'Nose'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Go':         ['GoTest'],

--- a/spec/karma_spec.vim
+++ b/spec/karma_spec.vim
@@ -1,0 +1,69 @@
+source spec/support/helpers.vim
+
+describe "Karma"
+
+  before
+    cd spec/fixtures/jasmine
+		let g:test#javascript#jasmine#file_pattern = '^none.js$'
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    SKIP "Disabled until functionality is implemented"
+    view +2 spec/normal_spec.js
+    TestNearest
+
+    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.js --filter=''Addition adds two numbers'''
+  end
+
+  it "runs file tests"
+    SKIP "Disabled until functionality is implemented"
+    view spec/normal_spec.js
+    TestFile
+
+    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.js'
+  end
+
+  it "runs test suites"
+    view spec/normal_spec.js
+    TestSuite
+
+    Expect g:test#last_command == 'karma start --single-run'
+  end
+
+  it "is case insensitive about the filename"
+    SKIP "Disabled until functionality is implemented"
+    view spec/normalSpec.js
+    TestFile
+
+    Expect g:test#last_command == 'karma start --single-run -- spec/normalSpec.js'
+  end
+
+  it "doesn't recognize files that don't end with 'spec'"
+    view spec/normal.js
+    TestFile
+
+    Expect exists('g:test#last_command') == 0
+  end
+
+  it "runs CoffeeScript"
+    SKIP "Disabled until functionality is implemented"
+    view spec/normal_spec.coffee
+    TestFile
+
+    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.coffee'
+  end
+
+  it "runs React"
+    SKIP "Disabled until functionality is implemented"
+    view spec/normal_spec.jsx
+    TestFile
+
+    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.jsx'
+  end
+
+end


### PR DESCRIPTION
Add a basic karma runner which doesn't restrict the tests being run in any way due to the limitations in how `karma` selects the tests to run.

resolves #123 