### PR TITLE
Add runner for M, a Test::Unit runner that runs tests by line number

### DIFF
--- a/autoload/test/ruby/m.vim
+++ b/autoload/test/ruby/m.vim
@@ -1,0 +1,33 @@
+if !exists('g:test#ruby#m#file_pattern')
+  let g:test#ruby#m#file_pattern = '_test\.rb$'
+endif
+
+function! test#ruby#m#test_file(file) abort
+  return a:file =~# g:test#ruby#m#file_pattern
+endfunction
+
+function! test#ruby#m#build_position(type, position) abort
+  if a:type == 'nearest'
+    return [a:position['file'].':'.a:position['line']]
+  elseif a:type == 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#ruby#m#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#ruby#m#executable() abort
+  if !empty(glob('.zeus.sock'))
+    return 'zeus m'
+  elseif filereadable('./bin/m')
+    return './bin/m'
+  elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)
+    return 'bundle exec m'
+  else
+    return 'm'
+  endif
+endfunction


### PR DESCRIPTION
https://github.com/qrush/m

The default minitest runner sometimes has issues with the nested spec
syntax. Describe > describe etc.

Let's not reinvent the wheel, let's use M.

Example .vimrc settings:

" register the M runner.
let test#runners = {'Ruby': ['M']}
" you want to set the runner_commands because otherwise the default
" minitest runner will be used. In our case we had multiple test
" suites.. legacy!
let g:test#runner_commands = ['M', 'Cucumber', 'Rspec']