### PR TITLE
Improve karma detection and add customizable karma.conf.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently the following testing frameworks are supported:
 | Language       | Frameworks                                 | Identifiers                                  |
 | :------------: | -------------------------------------      | -------------------------------------------- |
 | **Ruby**       | RSpec, [Minitest][minitest], [M], Cucumber | `rspec`, `minitest`, `m`, `cucumber`         |
-| **JavaScript** | Intern, TAP, Mocha, Jasmine, Karma         | `intern`, `tap`, `mocha`, `jasmine`, `karma` |
+| **JavaScript** | Intern, TAP, Karma, Mocha, Jasmine         | `intern`, `tap`, `karma`, `mocha`, `jasmine` |
 | **Python**     | Nose, PyTest, Django                       | `nose`, `pytest`, `djangotest`, `djangonose` |
 | **Elixir**     | ExUnit, ESpec                              | `exunit`, `espec`                            |
 | **Go**         | Go                                         | `gotest`                                     |

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -1,9 +1,13 @@
 if !exists('g:test#javascript#karma#file_pattern')
-  let g:test#javascript#karma#file_pattern = '\v^spec/.*spec\.(js|jsx|coffee)$'
+  let g:test#javascript#karma#file_pattern = '\v(test|spec)\.(js|jsx|coffee)$'
 endif
 
 function! test#javascript#karma#test_file(file) abort
-  return a:file =~? g:test#javascript#karma#file_pattern
+  if empty(test#javascript#karma#executable())
+    return 0
+  endif
+
+  return  a:file =~? g:test#javascript#karma#file_pattern
 endfunction
 
 function! test#javascript#karma#build_position(type, position) abort
@@ -13,7 +17,7 @@ function! test#javascript#karma#build_position(type, position) abort
 endfunction
 
 function! test#javascript#karma#build_args(args) abort
-  let args = a:args
+  let args = ['start'] + a:args + ['--single-run']
 
   if test#base#no_colors()
     let args = ['--no-color'] + args
@@ -24,11 +28,9 @@ endfunction
 
 function! test#javascript#karma#executable() abort
   if filereadable('node_modules/.bin/karma')
-    let karma_exec = 'node_modules/.bin/karma'
-  else
-    let karma_exec = 'karma'
+    return 'node_modules/.bin/karma'
   endif
-	return karma_exec . ' start --single-run'
+  return ''
 endfunction
 
 function! s:nearest_test(position)

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -14,7 +14,7 @@ endfunction
 let g:test#runners = get(g:, 'test#runners', {})
 call s:extend(g:test#runners, {
   \ 'Ruby':       ['M', 'Minitest', 'RSpec', 'Cucumber'],
-  \ 'JavaScript': ['Intern', 'TAP', 'Mocha', 'Jasmine', 'Karma'],
+  \ 'JavaScript': ['Intern', 'TAP', 'Karma', 'Mocha', 'Jasmine'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'Nose'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Go':         ['GoTest'],

--- a/spec/fixtures/karma/normal_spec.js
+++ b/spec/fixtures/karma/normal_spec.js
@@ -1,0 +1,5 @@
+describe('Addition', function() {
+  it('adds two numbers', function() {
+    expect(1 + 1).toEqual(true);
+  });
+});

--- a/spec/karma_spec.vim
+++ b/spec/karma_spec.vim
@@ -2,68 +2,85 @@ source spec/support/helpers.vim
 
 describe "Karma"
 
-  before
-    cd spec/fixtures/jasmine
-		let g:test#javascript#jasmine#file_pattern = '^none.js$'
+  describe "with executable"
+    before
+      cd spec/fixtures/karma
+    end
+
+    after
+      call Teardown()
+      cd -
+    end
+
+    it "runs nearest tests"
+      SKIP "Disabled until functionality is implemented"
+      view +2 normal_spec.js
+      TestNearest
+
+      Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.js --filter=''Addition adds two numbers'''
+    end
+
+    it "runs file tests"
+      SKIP "Disabled until functionality is implemented"
+      view normal_spec.js
+      TestFile
+
+      Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.js'
+    end
+
+    it "runs test suites"
+      view normal_spec.js
+      TestSuite
+
+      Expect g:test#last_command == 'node_modules/.bin/karma start --single-run'
+    end
+
+    it "detects tests in files ending with 'test'"
+      view normal_test.js
+      TestSuite
+
+      Expect g:test#last_command == 'node_modules/.bin/karma start --single-run'
+    end
+
+    it "is case insensitive about the filename"
+      view normalSpec.js
+      TestSuite
+
+      Expect g:test#last_command == 'node_modules/.bin/karma start --single-run'
+    end
+
+    it "doesn't recognize files that don't end with 'spec' or 'test'"
+      view normal.js
+      TestFile
+
+      Expect exists('g:test#last_command') == 0
+    end
+
+    it "runs CoffeeScript"
+      view spec/normal_spec.coffee
+      TestSuite
+
+      Expect g:test#last_command == 'node_modules/.bin/karma start --single-run'
+    end
+
+    it "runs React"
+      view spec/normal_spec.jsx
+      TestSuite
+
+      Expect g:test#last_command == 'node_modules/.bin/karma start --single-run'
+    end
   end
 
-  after
-    call Teardown()
-    cd -
+  describe "without executable"
+    after
+      call Teardown()
+    end
+
+    it "doesn't run test suites"
+      view normal_spec.js
+      TestSuite
+
+      Expect exists('g:test#last_command') == 0
+    end
   end
-
-  it "runs nearest tests"
-    SKIP "Disabled until functionality is implemented"
-    view +2 spec/normal_spec.js
-    TestNearest
-
-    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.js --filter=''Addition adds two numbers'''
-  end
-
-  it "runs file tests"
-    SKIP "Disabled until functionality is implemented"
-    view spec/normal_spec.js
-    TestFile
-
-    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.js'
-  end
-
-  it "runs test suites"
-    view spec/normal_spec.js
-    TestSuite
-
-    Expect g:test#last_command == 'karma start --single-run'
-  end
-
-  it "is case insensitive about the filename"
-    SKIP "Disabled until functionality is implemented"
-    view spec/normalSpec.js
-    TestFile
-
-    Expect g:test#last_command == 'karma start --single-run -- spec/normalSpec.js'
-  end
-
-  it "doesn't recognize files that don't end with 'spec'"
-    view spec/normal.js
-    TestFile
-
-    Expect exists('g:test#last_command') == 0
-  end
-
-  it "runs CoffeeScript"
-    SKIP "Disabled until functionality is implemented"
-    view spec/normal_spec.coffee
-    TestFile
-
-    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.coffee'
-  end
-
-  it "runs React"
-    SKIP "Disabled until functionality is implemented"
-    view spec/normal_spec.jsx
-    TestFile
-
-    Expect g:test#last_command == 'karma start --single-run -- spec/normal_spec.jsx'
-  end
-
 end


### PR DESCRIPTION
Improve the way we detect karma as our test runner so that it is more
relaxed on the file names, but will check for the karma executable and
the presence of the karma.conf.js file. The name and/or location of the
karma.conf.js can be customized by setting
g:test#javascript#karma#conffile.

Closes #127