### PR TITLE
async tests support for python

### DIFF
--- a/autoload/test/python.vim
+++ b/autoload/test/python.vim
@@ -1,4 +1,4 @@
 let test#python#patterns = {
-  \ 'test':      ['\v^\s*def (test_\w+)'],
+  \ 'test':      ['\v^\s*%(async )?def (test_\w+)'],
   \ 'namespace': ['\v^\s*class (\w+)'],
 \}


### PR DESCRIPTION
In python 3.5 syntax for creating coroutines on a language level have been added.
Because of that libraries like pytest-asyncio have been created, that can decorate test that is written as a coroutine object and run it in a loop.

```
@pytest.mark.asyncio
async def test_some():
    assert await some_awaitable() == some_expected_result