### PR TITLE
Fix failing tests for Elixir umbrella applications

### DIFF
--- a/autoload/test/elixir/exunit.vim
+++ b/autoload/test/elixir/exunit.vim
@@ -7,17 +7,19 @@ function! test#elixir#exunit#test_file(file) abort
 endfunction
 
 function! test#elixir#exunit#build_position(type, position) abort
+  let file = fnamemodify(a:position['file'], ':p')
+
   if test#elixir#exunit#executable() == 'mix test'
     if a:type == 'nearest'
-      return [a:position['file'].':'.a:position['line']]
+      return [file.':'.a:position['line']]
     elseif a:type == 'file'
-      return [a:position['file']]
+      return [file]
     else
       return []
     endif
   else
     if a:type == 'nearest' || a:type == 'file'
-      return [a:position['file']]
+      return [file]
     else
       return ['*.exs']
     end

--- a/spec/exunit_spec.vim
+++ b/spec/exunit_spec.vim
@@ -16,14 +16,14 @@ describe "ExUnit"
       view +1 normal_test.exs
       TestNearest
 
-      Expect g:test#last_command == 'mix test normal_test.exs:1'
+      Expect g:test#last_command == 'mix test ' . getcwd() . '/normal_test.exs:1'
     end
 
     it "runs file tests"
       view normal_test.exs
       TestFile
 
-      Expect g:test#last_command == 'mix test normal_test.exs'
+      Expect g:test#last_command == 'mix test ' . getcwd() . '/normal_test.exs'
     end
 
     it "runs test suites"
@@ -43,14 +43,14 @@ describe "ExUnit"
       view +1 normal_test.exs
       TestNearest
 
-      Expect g:test#last_command == 'elixir normal_test.exs'
+      Expect g:test#last_command == 'elixir ' . getcwd() . '/normal_test.exs'
     end
 
     it "runs file tests"
       view normal_test.exs
       TestFile
 
-      Expect g:test#last_command == 'elixir normal_test.exs'
+      Expect g:test#last_command == 'elixir ' . getcwd() . '/normal_test.exs'
     end
 
     it "runs test suites"


### PR DESCRIPTION
When running a specific test in Elixir, the file has to be either an absolute path or a path relative to the umbrella app.

As it's not easily possible to know if a project is under an umbrella application, the fix is to use an absolute path.

Fixes #136