### PR TITLE
Fix 'basic' startegy on Windows

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -97,9 +97,9 @@ function! s:pretty_command(cmd) abort
   let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
 
   if !exists('g:test#preserve_screen') || !g:test#preserve_screen
-    return join([l:clear, l:cd, l:echo, a:cmd], '; ')
+    return join([l:clear, l:cd, l:echo, a:cmd], has('win32') ? ' & ' : '; ')
   else
-    return join([l:cd, l:echo, a:cmd], '; ')
+    return join([l:cd, l:echo, a:cmd], has('win32') ? ' & ' : '; ')
   endif
 endfunction
 


### PR DESCRIPTION
When I like to run a test, the `cmd.exe` says:

  The system cannot find the path specified

The source of this problem is that Windows using `&` to separate
commands, `;` for command line parameters.

See:
www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/ntcmds_shelloverview.mspx