### PR TITLE
Add VimProc as a new strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -42,6 +42,10 @@ function! test#strategy#dispatch(cmd) abort
   execute 'Dispatch '.a:cmd
 endfunction
 
+function! test#strategy#vimproc(cmd) abort
+  execute 'VimProcBang '.a:cmd
+endfunction
+
 function! test#strategy#neovim(cmd) abort
   let opts = {'suffix': ' # vim-test'}
   function! opts.close_terminal()

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -169,6 +169,12 @@ Runs test commands with `:Dispatch`. Requires the Dispatch.vim plugin.
 >
   let test#strategy = 'dispatch'
 <
+VimProc ~
+
+Runs test commands with `:VimProcBang`. Requires the Vimproc.vim plugin.
+>
+  let test#strategy = 'vimproc'
+<
 Neovim ~
 
 Runs test commands with `:terminal`, which spawns a terminal inside your Neovim.


### PR DESCRIPTION
To catch the results of the test to a buffer, use `:Verbose TestFile` with Tim Pope's Scriptease plugin.