### PR TITLE
Change rails version detection method

### DIFF
--- a/autoload/test/ruby/rails.vim
+++ b/autoload/test/ruby/rails.vim
@@ -38,10 +38,14 @@ endfunction
 
 function! s:rails_version()
   if filereadable('Gemfile.lock')
-    let gemfile_lock = system('cat Gemfile.lock')
-    let version_string = matchstr(gemfile_lock, '\v^rails \(\zs.+\ze\)')
+    for line in readfile('Gemfile.lock')
+      let version_string = matchstr(line, '\v^ *rails \(\zs\d+\.\d+\..+\ze\)')
+      if version_string
+        break
+      endif
+    endfor
 
-    if !empty(version_string)
+    if version_string
       let rails_version = matchlist(version_string, '\v(\d+)\.(\d+)\.(\d+)%(\.(\d+))?')[1:-1]
       call filter(rails_version, '!empty(v:val)')
       call map(rails_version, 'str2nr(v:val)')


### PR DESCRIPTION
 I am not exactly sure why though, at least for my environment, Rails version detection always fails because `cat Gemfile.lock` returns long one-liner which includes newline symbols and the regex also fails because of leading whitespaces in `Gemfile.lock`.

So I have changed the Rails version detection method to more reliable one using Vim builtin function.

How does this sound to you?

FYI: 
macOS 10.12.1

```
$ vim --version                                                                                                                                                    
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Dec 16 2016 10:35:52)
MacOS X (unix) version
Included patches: 1-134
Compiled by Homebrew
```