### PR TITLE
nearest strategy now executes only one test and test classes work also

### DIFF
--- a/autoload/test/python/pytest.vim
+++ b/autoload/test/python/pytest.vim
@@ -16,7 +16,7 @@ function! test#python#pytest#build_position(type, position) abort
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      return [a:position['file'].' -k '.name]
+      return [a:position['file'].'::'.name]
     else
       return [a:position['file']]
     endif
@@ -43,5 +43,9 @@ endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#python#patterns)
-  return get(name['test'], 0, '')
+  let path = get(name['test'], 0, '')
+  if len(name['namespace'])
+      let path = name['namespace'][0] . '::' . path
+  endif
+  return path
 endfunction


### PR DESCRIPTION
Thanks to github it's all in the name. I've found some time to properly implement this. I've tested two use cases. One when test is a module level function and one where test is a method of a class.
Wasn't very hard to do, because you've already searching for namespace and it's available. The only thing that stopped me before is that my knowledge of vimscript was worse than it is now.