### PR TITLE
If there is a nwb config present then run `nwb test`

### DIFF
--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -47,7 +47,9 @@ function! test#javascript#karma#build_args(args) abort
 endfunction
 
 function! test#javascript#karma#executable() abort
-  if filereadable('node_modules/karma-cli-runner/karma-args.js')
+  if filereadable('nwb.config.js')
+    return 'nwb test'
+  elseif filereadable('node_modules/karma-cli-runner/karma-args.js')
     return 'node node_modules/karma-cli-runner/karma-args'
   elseif filereadable('node_modules/.bin/karma')
     return 'node_modules/.bin/karma start --single-run'


### PR DESCRIPTION
I am currently working on application using [nwb which requires you to run nwb test](https://github.com/insin/nwb/blob/master/docs/Commands.md#test). This is a quick PR to get vim-test to check for the presence of the nwb config.