### PR TITLE
Add support for crystal

### DIFF
--- a/autoload/test/crystal.vim
+++ b/autoload/test/crystal.vim
@@ -1,0 +1,9 @@
+let test#crystal#patterns = {
+  \ 'test': [
+    \ '\v^\s*it%(\(| )%("|'')(.*)%("|'')',
+  \],
+  \ 'namespace': [
+    \ '\v^\s*describe%(\(| )%("|'')(.*)%("|'')',
+    \ '\v^\s*describe%(\(| )(\S+)',
+  \],
+\}

--- a/autoload/test/crystal/crystalspec.vim
+++ b/autoload/test/crystal/crystalspec.vim
@@ -1,0 +1,25 @@
+if !exists('g:test#crystal#crystalspec#file_pattern')
+  let g:test#crystal#crystalspec#file_pattern = '\v(_spec\.cr)$'
+endif
+
+function! test#crystal#crystalspec#test_file(file) abort
+  return a:file =~# g:test#crystal#crystalspec#file_pattern
+endfunction
+
+function! test#crystal#crystalspec#build_position(type, position) abort
+  if a:type == 'nearest'
+    return [a:position['file'].':'.a:position['line']]
+  elseif a:type == 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#crystal#crystalspec#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#crystal#crystalspec#executable() abort
+  return 'crystal spec'
+endfunction

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -26,6 +26,7 @@ call s:extend(g:test#runners, {
   \ 'PHP':        ['Codeception', 'PHPUnit', 'Behat', 'PHPSpec'],
   \ 'Perl':       ['Prove'],
   \ 'Java':       ['MavenTest'],
+  \ 'Crystal':    ['CrystalSpec'],
 \})
 
 let g:test#custom_strategies = get(g:, 'test#custom_strategies', {})

--- a/spec/crystal_spec.vim
+++ b/spec/crystal_spec.vim
@@ -1,0 +1,34 @@
+source spec/support/helpers.vim
+
+describe "Crystal"
+
+  before
+    cd spec/fixtures/crystal
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +1 normal_spec.cr
+    TestNearest
+
+    Expect g:test#last_command == 'crystal spec normal_spec.cr:1'
+  end
+
+  it "runs file tests"
+    view normal_spec.cr
+    TestFile
+
+    Expect g:test#last_command == 'crystal spec normal_spec.cr'
+  end
+
+  it "runs test suites"
+    view normal_spec.cr
+    TestSuite
+
+    Expect g:test#last_command == 'crystal spec'
+  end
+end

--- a/spec/fixtures/crystal/normal_spec.cr
+++ b/spec/fixtures/crystal/normal_spec.cr
@@ -1,0 +1,5 @@
+describe "Addition" do
+  it "adds to numbers" do
+    (1 + 1).should eq(2)
+  end
+end


### PR DESCRIPTION
This adds support for the crystal programming language, which has a built in test runner that is much like rspec.