### PR TITLE
Add support for Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Currently the following testing frameworks are supported:
 
 | Language       | Frameworks                                      | Identifiers                                  |
 | :------------: | -------------------------------------           | -------------------------------------------- |
-| **Ruby**       | RSpec, [Minitest][minitest]/Rails/[M], Cucumber | `rspec`, `minitest`/`rails`/`m`, `cucumber`  |
-| **JavaScript** | Intern, TAP, Karma, Mocha, Jasmine              | `intern`, `tap`, `karma`, `mocha`, `jasmine` |
+| **Ruby**       | RSpec, [Minitest][minitest]/Rails/[M], Cucumber             | `rspec`, `minitest`/`rails`/`m`, `cucumber`  |
+| **JavaScript** | Intern, TAP, Karma, Mocha, Jasmine, Jest        | `intern`, `tap`, `karma`, `mocha`, `jasmine`, `jest` |
 | **Python**     | Nose, PyTest, Django                            | `nose`, `pytest`, `djangotest`, `djangonose` |
 | **Elixir**     | ExUnit, ESpec                                   | `exunit`, `espec`                            |
 | **Go**         | Go                                              | `gotest`                                     |

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -1,0 +1,40 @@
+if !exists('g:test#javascript#jest#file_pattern')
+  let g:test#javascript#jest#file_pattern = '\v^__tests__/.*-test\.(js|jsx|coffee)$'
+endif
+
+function! test#javascript#jest#test_file(file) abort
+  return a:file =~# g:test#javascript#jest#file_pattern
+endfunction
+
+function! test#javascript#jest#build_position(type, position) abort
+  if a:type == 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      let name = '-t '.shellescape(name, 1)
+    endif
+    return [a:position['file'], name]
+  elseif a:type == 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#javascript#jest#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#javascript#jest#executable() abort
+  if filereadable('node_modules/.bin/jest')
+    return 'node_modules/.bin/jest'
+  else
+    return 'jest'
+  endif
+endfunction
+
+function! s:nearest_test(position)
+  let name = test#base#nearest_test(a:position, g:test#javascript#patterns)
+  return (len(name['namespace']) ? '^' : '') .
+       \ test#base#escape_regex(join(name['namespace'] + name['test'])) .
+       \ (len(name['test']) ? '$' : '')
+endfunction

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -14,7 +14,7 @@ endfunction
 let g:test#runners = get(g:, 'test#runners', {})
 call s:extend(g:test#runners, {
   \ 'Ruby':       ['Rails', 'M', 'Minitest', 'RSpec', 'Cucumber'],
-  \ 'JavaScript': ['Intern', 'TAP', 'Karma', 'Mocha', 'Jasmine'],
+  \ 'JavaScript': ['Intern', 'TAP', 'Karma', 'Mocha', 'Jasmine', 'Jest'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'Nose'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Go':         ['GoTest'],

--- a/spec/fixtures/jest/__tests__/context-test.js
+++ b/spec/fixtures/jest/__tests__/context-test.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  context('Addition', function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});

--- a/spec/fixtures/jest/__tests__/normal-test.coffee
+++ b/spec/fixtures/jest/__tests__/normal-test.coffee
@@ -1,0 +1,4 @@
+describe 'Math', ->
+  describe 'Addition', ->
+    it 'adds two numbers', ->
+      # assertions

--- a/spec/fixtures/jest/__tests__/normal-test.js
+++ b/spec/fixtures/jest/__tests__/normal-test.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  describe('Addition', function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});

--- a/spec/fixtures/jest/__tests__/normal-test.jsx
+++ b/spec/fixtures/jest/__tests__/normal-test.jsx
@@ -1,0 +1,8 @@
+describe('Math', function() {
+  describe('Addition', function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});
+

--- a/spec/fixtures/jest/outside-test.js
+++ b/spec/fixtures/jest/outside-test.js
@@ -1,0 +1,5 @@
+describe('Addition', function() {
+  it('adds two numbers', function() {
+    assertEqual(1 + 1 == 2)
+  });
+});

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -1,0 +1,113 @@
+source spec/support/helpers.vim
+
+describe "Jest"
+
+  before
+    cd spec/fixtures/jest
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  context "on nearest tests"
+    it "runs JavaScript"
+      view +1 __tests__/normal-test.js
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.js -t ''^Math'''
+
+      view +2 __tests__/normal-test.js
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.js -t ''^Math Addition'''
+
+      view +3 __tests__/normal-test.js
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.js -t ''^Math Addition adds two numbers$'''
+    end
+
+    it "aliases context to describe"
+      view +1 __tests__/context-test.js
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/context-test.js -t ''^Math'''
+
+      view +2 __tests__/context-test.js
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/context-test.js -t ''^Math Addition'''
+
+      view +3 __tests__/context-test.js
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/context-test.js -t ''^Math Addition adds two numbers$'''
+    end
+
+    it "runs CoffeeScript"
+      view +1 __tests__/normal-test.coffee
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.coffee -t ''^Math'''
+
+      view +2 __tests__/normal-test.coffee
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.coffee -t ''^Math Addition'''
+
+      view +3 __tests__/normal-test.coffee
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.coffee -t ''^Math Addition adds two numbers$'''
+    end
+
+    it "runs React"
+      view +1 __tests__/normal-test.jsx
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.jsx -t ''^Math'''
+
+      view +2 __tests__/normal-test.jsx
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.jsx -t ''^Math Addition'''
+
+      view +3 __tests__/normal-test.jsx
+      TestNearest
+
+      Expect g:test#last_command == 'jest __tests__/normal-test.jsx -t ''^Math Addition adds two numbers$'''
+    end
+  end
+
+  it "runs file test if nearest test couldn't be found"
+    view +1 __tests__/normal-test.js
+    normal O
+    TestNearest
+
+    Expect g:test#last_command == 'jest __tests__/normal-test.js'
+  end
+
+  it "runs file tests"
+    view __tests__/normal-test.js
+    TestFile
+
+    Expect g:test#last_command == 'jest __tests__/normal-test.js'
+  end
+
+  it "runs test suites"
+    view __tests__/normal-test.js
+    TestSuite
+
+    Expect g:test#last_command == 'jest'
+  end
+
+  it "doesn't detect JavaScripts which are not in the __tests__/ folder"
+    view outside-test.js
+    TestSuite
+
+    Expect exists('g:test#last_command') == 0
+  end
+
+end


### PR DESCRIPTION
Runs tests from the `__tests__` directory, file names must end in `-test.js|jsx|coffee` .

I can make the file pattern more flexible, that's open to discussion.