### PR TITLE
Add dotnet test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently the following testing frameworks are supported:
 | **Perl**       | Prove                                           | `prove`                                      |
 | **Java**       | Maven                                           | `maventest`                                  |
 | **Crystal**    | Crystal                                         | `crystalspec`                                |
+| **C#**         | dotnet test                                     | `dotnettest`                                 |
 
 ## Features
 

--- a/autoload/test/cs.vim
+++ b/autoload/test/cs.vim
@@ -1,4 +1,4 @@
 let test#cs#patterns = {
-  \ 'test':      ['\v^\s*public void (\w+)'],
+  \ 'test':      ['\v^\s*public void (\w+)', '\v^\s*public async void (\w+)'],
   \ 'namespace': ['\v^\s*public class (\w+)'],
 \}

--- a/autoload/test/cs.vim
+++ b/autoload/test/cs.vim
@@ -1,0 +1,4 @@
+let test#cs#patterns = {
+  \ 'test':      ['\v^\s*public void (\w+)'],
+  \ 'namespace': ['\v^\s*public class (\w+)'],
+\}

--- a/autoload/test/cs/dotnettest.vim
+++ b/autoload/test/cs/dotnettest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#cs#dotnettest#file_pattern')
-  let g:test#cs#dotnettest#file_pattern = '\v^.*[Tt]ests\.cs$'
+  let g:test#cs#dotnettest#file_pattern = '\v^.*\.cs$'
 endif
 
 function! test#cs#dotnettest#test_file(file) abort

--- a/autoload/test/cs/dotnettest.vim
+++ b/autoload/test/cs/dotnettest.vim
@@ -1,0 +1,59 @@
+if !exists('g:test#cs#dotnettest#file_pattern')
+  let g:test#cs#dotnettest#file_pattern = '\v^.*[Tt]ests\.cs$'
+endif
+
+function! test#cs#dotnettest#test_file(file) abort
+  return a:file =~? g:test#cs#dotnettest#file_pattern
+endfunction
+
+function! test#cs#dotnettest#build_position(type, position) abort
+  let file = a:position['file']
+  let filename = fnamemodify(file, ':t:r')
+  let filedir = fnamemodify(file, ':p:h')
+  let projfiles = split(glob(filedir . '/*.csproj'), '\n')
+  let search_for_csproj = 1
+
+  while len(projfiles) == 0 && search_for_csproj
+    let filedirparts = split(filedir, '/') 
+    let search_for_csproj = len(filedir) > 1
+    let filedir = '/'.join(filedirparts[0:-2], '/')
+    let projfiles = split(glob(filedir . '/*.csproj'), '\n')
+  endwhile
+
+  if len(projfiles) == 0
+    throw 'Unable to find .csproj file, a .csproj file is required to make use of the `dotnet test` command.'
+  endif
+
+  let projectPath = projfiles[0]
+
+  if a:type == 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      return [name, projectPath]
+    else
+      return [filename, projectPath]
+    endif
+  elseif a:type == 'file'
+    return [filename, projectPath]
+  else
+    return ['*', projectPath]
+  endif
+endfunction
+
+function! test#cs#dotnettest#build_args(args) abort
+  let filter = ''
+  if a:args[0] != '*'
+    let filter = ' --filter FullyQualifiedName\~'.a:args[0]
+  endif
+  let args = ['test ', a:args[1], filter]
+  return [join(args, "")]
+endfunction
+
+function! test#cs#dotnettest#executable() abort
+  return 'dotnet'
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#cs#patterns)
+  return join(name['namespace'] + name['test'], '.')
+endfunction

--- a/autoload/test/cs/dotnettest.vim
+++ b/autoload/test/cs/dotnettest.vim
@@ -9,34 +9,34 @@ endfunction
 function! test#cs#dotnettest#build_position(type, position) abort
   let file = a:position['file']
   let filename = fnamemodify(file, ':t:r')
-  let filedir = fnamemodify(file, ':p:h')
-  let projfiles = split(glob(filedir . '/*.csproj'), '\n')
+  let filepath = fnamemodify(file, ':p:h')
+  let project_files = split(glob(filepath . '/*.csproj'), '\n')
   let search_for_csproj = 1
 
-  while len(projfiles) == 0 && search_for_csproj
-    let filedirparts = split(filedir, '/') 
-    let search_for_csproj = len(filedir) > 1
-    let filedir = '/'.join(filedirparts[0:-2], '/')
-    let projfiles = split(glob(filedir . '/*.csproj'), '\n')
+  while len(project_files) == 0 && search_for_csproj
+    let filepath_parts = split(filepath, '/') 
+    let search_for_csproj = len(filepath_parts) > 1
+    let filepath = '/'.join(filepath_parts[0:-2], '/')
+    let project_files = split(glob(filepath . '/*.csproj'), '\n')
   endwhile
 
-  if len(projfiles) == 0
+  if len(project_files) == 0
     throw 'Unable to find .csproj file, a .csproj file is required to make use of the `dotnet test` command.'
   endif
 
-  let projectPath = projfiles[0]
+  let project_path = project_files[0]
 
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      return [name, projectPath]
+      return [name, project_path]
     else
-      return [filename, projectPath]
+      return [filename, project_path]
     endif
   elseif a:type == 'file'
-    return [filename, projectPath]
+    return [filename, project_path]
   else
-    return ['*', projectPath]
+    return ['*', project_path]
   endif
 endfunction
 
@@ -45,12 +45,12 @@ function! test#cs#dotnettest#build_args(args) abort
   if a:args[0] != '*'
     let filter = ' --filter FullyQualifiedName\~'.a:args[0]
   endif
-  let args = ['test ', a:args[1], filter]
+  let args = [a:args[1], filter]
   return [join(args, "")]
 endfunction
 
 function! test#cs#dotnettest#executable() abort
-  return 'dotnet'
+  return 'dotnet test'
 endfunction
 
 function! s:nearest_test(position) abort

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -20,6 +20,7 @@ call s:extend(g:test#runners, {
   \ 'Go':         ['GoTest'],
   \ 'Rust':       ['CargoTest'],
   \ 'Clojure':    ['FireplaceTest'],
+  \ 'cs':         ['dotnettest'],
   \ 'Shell':      ['Bats'],
   \ 'VimL':       ['VSpec', 'Vader'],
   \ 'Lua':        ['Busted'],

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -1,0 +1,65 @@
+source spec/support/helpers.vim
+
+function! s:remove_path(cmd)
+  return substitute(a:cmd, '\/.*\/spec\/fixtures\/dotnet\/', '', '')
+endfunction
+
+describe "dotnet"
+
+  before
+    let g:test#cs#runner = 'dotnet'
+    cd spec/fixtures/dotnet
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +2 Tests.cs
+    TestNearest
+
+    let actual = s:remove_path(g:test#last_command) 
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests'
+
+    view +8 Tests.cs
+    TestNearest
+
+    let actual = s:remove_path(g:test#last_command) 
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests.TestAsync'
+
+    view +14 Tests.cs
+    TestNearest
+
+    let actual = s:remove_path(g:test#last_command) 
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests.Test'
+
+  end
+
+  it "runs file test if nearest test couldn't be found"
+    view +1 Tests.cs
+    normal O
+    TestNearest
+
+    let actual = s:remove_path(g:test#last_command) 
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests'
+  end
+
+  it "runs file tests"
+    view Tests.cs
+    TestFile
+
+    let actual = s:remove_path(g:test#last_command) 
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests'
+  end
+
+  it "runs test suites"
+    view Tests.cs
+    TestSuite
+
+    let actual = s:remove_path(g:test#last_command) 
+    Expect actual == 'dotnet test Tests.csproj'
+  end
+
+end

--- a/spec/fixtures/dotnet/Tests.cs
+++ b/spec/fixtures/dotnet/Tests.cs
@@ -1,0 +1,17 @@
+namespace Namespace
+{
+    public class Tests
+    {
+        [Fact]
+        public async void TestAsync()
+        {
+            Assert.Equal(true, false);
+        }
+
+        [Fact]
+        public void Test()
+        {
+            Assert.Equal(true, false);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a runner for the dotnet cli command `dotnet test`. 

I'd appreciate any input about the logic I am using to find the nearest `.csproj` file, I'm not great with vimscript. Finding the nearest `.csproj` file is required because the path is a required argument to `dotnet test`. I've tested this out using an underlying xunit test project as well as an mstest one, both work fine. All of the functionality `:TestFile`, `:TestSuite`, and `:TestNearest` work as expected. 