### PR TITLE
Add neomake strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ let test#strategy = "dispatch"
 | **[Vimux]**                     | `vimux`    | Runs test commands in a small tmux pane at the bottom of your terminal.          |
 | **[Tslime]**                    | `tslime`   | Runs test commands in a tmux pane you specify.                                   |
 | **[Neoterm]**                   | `neoterm`  | Runs test commands with `:T`, see neoterm docs for display customization.        |
+| **[Neomake]**                   | `neomake`  | Runs test commands asynchronously with `:Neomake`                                 |
 | **[VimShell]**                  | `vimshell` | Runs test commands in a shell written in VimScript.                              |
 | **[Vim&nbsp;Tmux&nbsp;Runner]** | `vtr`      | Runs test commands in a small tmux pane.                                         |
 | **[VimProc]**                   | `vimproc`  | Runs test commands asynchronously.                                               |
@@ -329,6 +330,7 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 
 [minitest]: https://github.com/janko-m/vim-test/wiki/Minitest
 [Neoterm]: https://github.com/kassio/neoterm
+[Neomake]: https://github.com/neomake/neomake
 [Dispatch]: https://github.com/tpope/vim-dispatch
 [Vimux]: https://github.com/benmills/vimux
 [Tslime]: https://github.com/jgdavey/tslime.vim

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -40,6 +40,39 @@ function! test#strategy#make(cmd) abort
   endtry
 endfunction
 
+function! test#strategy#neomake(cmd) abort
+
+  try
+    let compiler = dispatch#compiler_for_program(a:cmd)
+  catch
+    let compiler = ''
+  endtry
+
+  try
+    if !empty(compiler)
+      let default_makeprg = &l:makeprg
+      let default_errorformat = &l:errorformat
+      let default_compiler = get(b:, 'current_compiler', '')
+      execute 'compiler ' . compiler
+    endif
+    let cmd_parts = split(a:cmd, ' ')
+    let executable = cmd_parts[0]
+    let args = join(cmd_parts[1:], ' ')
+    let maker = {'exe': executable, 'name': executable, 'args': args,  'errorformat': &l:errorformat}
+    call neomake#Make(0, [maker])
+  finally
+    if !empty(compiler)
+      let &l:makeprg = default_makeprg
+      let &l:errorformat = default_errorformat
+      if empty(default_compiler)
+        unlet! b:current_compiler
+      else
+        let b:current_compiler = default_compiler
+      endif
+    endif
+  endtry
+endfunction
+
 function! test#strategy#asyncrun(cmd) abort
   execute 'AsyncRun '.a:cmd
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -203,6 +203,14 @@ Runs test commands with `:T`. Requires the Neoterm plugin.
 >
   let test#strategy = 'neoterm'
 <
+Neomake ~
+
+Runs test commands with `:Neomake`. Requires the Neomake plugin. This strategy will also use the Dispatch
+plugin to figure out what errorformat to use when calling Neomake, if Dispatch is not installed then the current
+errorformat will be used, this may mean you need to remember to set the compiler correctly when running tests.
+>
+  let test#strategy = 'neomake'
+<
 Vimux ~
 
 Runs test commands in a small Tmux pane at the bottom of your Terminal.


### PR DESCRIPTION
This is a neomake strategy, as per the discussion in https://github.com/janko-m/vim-test/issues/153.

I'm not sure if the implementation is perfect but it works with Dispatch where possible but otherwise falls back to the using the last set `errorformat`. 

I tried to use a convention similar to https://github.com/markwoodhall/vim-cljreloaded/blob/master/plugin/cljreloaded.vim#L15 in order to check if the `compiler_for_program` function exists but I believe that will only return true if the function has actually been loaded, which might not be the case if it has not been run yet. 