### PR TITLE
Create test#cd_before_run config

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ different working directory for running tests:
 let test#project_root = "/path/to/your/project"
 ```
 
+Similarly, some strategies will first issue a `cd` into vim's working directory
+before running. You can tell test.vim to disable this behavior:
+
+```vim
+let test#strategy#cd_before_run = 0
+```
+
+Note that if `test#project_root` is set, test.vim will still issue a `cd` into
+that directory before running, even if `test#strategy#cd_before_run` is
+disabled. It just won't perform any additional strategy-specific `cd`s.
+
 ### Language-specific
 
 #### Python

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -146,19 +146,28 @@ function! s:pretty_command(cmd) abort
   let cd = 'cd ' . shellescape(getcwd())
   let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
   let separator = !s:Windows() ? '; ' : ' & '
+  let commands = get(g:, 'test#preserve_screen') ? [] : [l:clear]
 
-  if !get(g:, 'test#preserve_screen')
-    return join([l:clear, l:cd, l:echo, a:cmd], l:separator)
-  else
-    return join([l:cd, l:echo, a:cmd], l:separator)
+  if !exists('g:test#cd_before_run') || g:test#cd_before_run
+    call add(l:commands, l:cd)
   endif
+
+  let l:commands += [l:echo, a:cmd]
+
+  return join(l:commands, l:separator)
 endfunction
 
 function! s:command(cmd) abort
   let cd = 'cd ' . shellescape(getcwd())
   let separator = !s:Windows() ? '; ' : ' & '
 
-  return join([l:cd, a:cmd], l:separator)
+  if !exists('g:test#cd_before_run') || g:test#cd_before_run
+    let commands = [l:cd, a:cmd]
+  else
+    let commands = [a:cmd]
+  endif
+
+  return join(l:commands, l:separator)
 endfunction
 
 function! s:Windows() abort

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -148,7 +148,7 @@ function! s:pretty_command(cmd) abort
   let separator = !s:Windows() ? '; ' : ' & '
   let commands = get(g:, 'test#preserve_screen') ? [] : [l:clear]
 
-  if !exists('g:test#cd_before_run') || g:test#cd_before_run
+  if s:cd_before_run()
     call add(l:commands, l:cd)
   endif
 
@@ -161,7 +161,7 @@ function! s:command(cmd) abort
   let cd = 'cd ' . shellescape(getcwd())
   let separator = !s:Windows() ? '; ' : ' & '
 
-  if !exists('g:test#cd_before_run') || g:test#cd_before_run
+  if s:cd_before_run()
     let commands = [l:cd, a:cmd]
   else
     let commands = [a:cmd]
@@ -188,4 +188,8 @@ function! s:cat(filename) abort
   else
     return system('cat '.a:filename)
   endif
+endfunction
+
+function! s:cd_before_run() abort
+  return !exists('g:test#strategy#cd_before_run') || g:test#strategy#cd_before_run
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -330,6 +330,11 @@ You can instruct test.vim to generate absolute file paths:
   let test#filename_modifier = ':p' " /User/janko/Code/my_project/test/models/user_test.rb
   let test#filename_modifier = ':~' " ~/Code/my_project/test/models/user_test.rb
 <
+By default, many strategies will first `cd` into vim's working directory before
+running a test command. You can disable this behavior using:
+>
+  let g:test#strategy#cd_before_run = 0
+<
 ABOUT                                           *test-about*
 
 You can get the latest version, see the changelog, or report a bug on GitHub:


### PR DESCRIPTION
This config value determines whether or not to cd into the project's
working directory before running the test. If not set, it will default
to true, which matches the existing behavior.

This could potentially lead to some confusion since, for example `test#strategy#basic` doesn't always do the `cd`, so this option would have no effect.

I think this is a good change because for example when using `rvm` sometimes a `cd` can have a lot of output and be slow.