### PR TITLE
add support for the Ginkgo framework of Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently the following testing frameworks are supported:
 | **JavaScript** | Intern, TAP, Karma, Lab, Mocha, Jasmine, Jest         | `intern`, `tap`, `karma`, `lab`, `mocha`, `jasmine`, `jest`       |
 | **Python**     | Nose, Nose2, PyTest, Django, unittest (PyUnit)        | `nose`, `nose2`, `pytest`, `djangotest`, `djangonose`, `pyunit`   |
 | **Elixir**     | ExUnit, ESpec                                         | `exunit`, `espec`                                                 |
-| **Go**         | Go                                                    | `gotest`                                                          |
+| **Go**         | Go, Ginkgo                                                    | `gotest`, `ginkgo`                                                          |
 | **Rust**       | Cargo                                                 | `cargotest`                                                       |
 | **Clojure**    | Fireplace.vim                                         | `fireplacetest`                                                   |
 | **Shell**      | Bats                                                  | `bats`                                                            |
@@ -256,6 +256,15 @@ the first available will be chosen, but you can force a specific one:
 let test#python#runner = 'pytest'
 " Runners available are 'pytest', 'nose', 'nose2', 'djangotest', 'djangonose' and Python's built-in 'unittest'
 ```
+
+#### Go
+
+For the same reason as Python, runner detection works the same for Go. To
+force a specific runner:
+
+``` vim
+let test#go#runner = 'ginkgo'
+" Runners available are 'gotest', 'ginkgo'
 
 #### Ruby
 

--- a/autoload/test/go.vim
+++ b/autoload/test/go.vim
@@ -2,3 +2,17 @@ let test#go#patterns = {
   \ 'test':      ['\v^\s*func (\w+)'],
   \ 'namespace': [],
 \}
+function! test#go#test_file(runner, file_pattern, file) abort
+  if fnamemodify(a:file, ':t') =~# a:file_pattern
+    " given the current runner, check if is can be used with the file
+    if exists('g:test#go#runner')
+      return a:runner == g:test#go#runner
+    endif
+    let contains_ginkgo_import = (search("github.com/onsi/ginkgo", 'n') > 0)
+    if a:runner == 'ginkgo'
+      return contains_ginkgo_import
+    else
+      return !contains_ginkgo_import
+    endif
+  endif
+endfunction

--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -11,7 +11,7 @@ function! test#go#ginkgo#test_file(file) abort
     if exists('g:test#go#runner')
       return g:test#go#runner == 'ginkgo'
     else
-      return executable('ginkgo')
+      return search("github.com/onsi/ginkgo") > 0
     endif
   endif
 endfunction

--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -7,13 +7,7 @@ let test#go#ginkgo#patterns = {
 \}
 
 function! test#go#ginkgo#test_file(file) abort
-  if fnamemodify(a:file, ':t') =~# g:test#go#ginkgo#file_pattern
-    if exists('g:test#go#runner')
-      return g:test#go#runner == 'ginkgo'
-    else
-      return search("github.com/onsi/ginkgo") > 0
-    endif
-  endif
+  return test#go#test_file('ginkgo', g:test#go#ginkgo#file_pattern, a:file)
 endfunction
 
 function! test#go#ginkgo#build_position(type, position) abort

--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -1,0 +1,50 @@
+if !exists('g:test#go#ginkgo#file_pattern')
+  let g:test#go#ginkgo#file_pattern = '\v[^_].*test\.go$'
+endif
+let test#go#ginkgo#patterns = {
+  \ 'test': ['\v^\s*It\("(.*)",', '\v^\s*Context\("(.*)",', '\v.*Describe\("(.*)",'],
+  \ 'namespace': [],
+\}
+
+function! test#go#ginkgo#test_file(file) abort
+  if fnamemodify(a:file, ':t') =~# g:test#go#ginkgo#file_pattern
+    if exists('g:test#go#runner')
+      return g:test#go#runner == 'ginkgo'
+    else
+      return executable('ginkgo')
+    endif
+  endif
+endfunction
+
+function! test#go#ginkgo#build_position(type, position) abort
+  if a:type == 'suite'
+    return ['./...']
+  else
+    let fileargs = ['--regexScansFilePath=true '.'--focus='.a:position['file']]
+    if a:type == 'file'
+      return fileargs
+    elseif a:type == 'nearest'
+      let path = './'.fnamemodify(a:position['file'], ':h')
+      let name = s:nearest_test(a:position)
+      " if no tests matched, run the test file
+      return empty(name) ? fileargs : ['--focus='.shellescape(name, 1), path]
+endfunction
+
+function! test#go#ginkgo#build_args(args) abort
+  let args = a:args
+
+  if test#base#no_colors()
+    let args = ['--nocolor'] + args
+  endif
+
+  return args
+endfunction
+
+function! test#go#ginkgo#executable() abort
+  return "ginkgo"
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#go#ginkgo#patterns)
+  return get(name['test'], 0, '')
+endfunction

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -7,7 +7,7 @@ function! test#go#gotest#test_file(file) abort
     if exists('g:test#go#runner')
       return g:test#go#runner == 'gotest'
     else
-      return executable('go')
+      return search("github.com/onsi/ginkgo") <= 0
     endif
   endif
 endfunction

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -3,7 +3,13 @@ if !exists('g:test#go#gotest#file_pattern')
 endif
 
 function! test#go#gotest#test_file(file) abort
-  return a:file =~# g:test#go#gotest#file_pattern
+  if fnamemodify(a:file, ':t') =~# g:test#go#gotest#file_pattern
+    if exists('g:test#go#runner')
+      return g:test#go#runner == 'gotest'
+    else
+      return executable('go')
+    endif
+  endif
 endfunction
 
 function! test#go#gotest#build_position(type, position) abort

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -3,13 +3,7 @@ if !exists('g:test#go#gotest#file_pattern')
 endif
 
 function! test#go#gotest#test_file(file) abort
-  if fnamemodify(a:file, ':t') =~# g:test#go#gotest#file_pattern
-    if exists('g:test#go#runner')
-      return g:test#go#runner == 'gotest'
-    else
-      return search("github.com/onsi/ginkgo") <= 0
-    endif
-  endif
+  return test#go#test_file('gotest', g:test#go#gotest#file_pattern, a:file)
 endfunction
 
 function! test#go#gotest#build_position(type, position) abort

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -123,6 +123,7 @@ In all commands [args] are forwarded to the underlying test runner.
 :GoTest [args]               Uses the `go` `test` command.
 
                                                 *test-:CargoTest*
+:Ginkgo [args]               Uses the `ginkgo` command.
 :CargoTest [args]            Uses the `cargo` `test` command.
 
                                                 *test-:FireplaceTest*

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -17,7 +17,7 @@ call s:extend(g:test#runners, {
   \ 'JavaScript': ['Intern', 'TAP', 'Karma', 'Lab', 'Mocha', 'Jasmine', 'Jest'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'PyUnit', 'Nose', 'Nose2'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
-  \ 'Go':         ['GoTest'],
+  \ 'Go':         ['GoTest', 'Ginkgo'],
   \ 'Rust':       ['CargoTest'],
   \ 'Clojure':    ['FireplaceTest'],
   \ 'CSharp':     ['DotnetTest'],

--- a/spec/fixtures/ginkgo/mypackage/normal_test.go
+++ b/spec/fixtures/ginkgo/mypackage/normal_test.go
@@ -1,0 +1,29 @@
+package mypackage_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("posts API", func() {
+
+	Context("when the request is authenticated", func() {
+
+		It("should return list of posts owned by the user", func() {
+
+		})
+
+		It("should paginate the result", func() {
+
+		})
+
+	})
+
+	Context("when the request is not authenticated", func() {
+
+		It("should deny access", func() {
+
+		})
+	})
+
+})

--- a/spec/fixtures/ginkgo/normal_test.go
+++ b/spec/fixtures/ginkgo/normal_test.go
@@ -1,0 +1,29 @@
+package mypackage_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("posts API", func() {
+
+	Context("when the request is authenticated", func() {
+
+		It("should return list of posts owned by the user", func() {
+
+		})
+
+		It("should paginate the result", func() {
+
+		})
+
+	})
+
+	Context("when the request is not authenticated", func() {
+
+		It("should deny access", func() {
+
+		})
+	})
+
+})

--- a/spec/ginkgo_spec.vim
+++ b/spec/ginkgo_spec.vim
@@ -46,7 +46,6 @@ describe "Ginkgo"
   it "runs file test if nearest test couldn't be found"
     view +1 mypackage/normal_test.go
     TestNearest
-    echo(g:test#last_command)
     Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=mypackage/normal_test.go"
   end
 

--- a/spec/ginkgo_spec.vim
+++ b/spec/ginkgo_spec.vim
@@ -1,0 +1,74 @@
+source spec/support/helpers.vim
+
+describe "Ginkgo"
+
+  before
+    let g:test#go#runner = 'ginkgo'
+    cd spec/fixtures/ginkgo
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  describe "runs nearest tests"
+    it "runs test identified by 'It'"
+      view +17 normal_test.go
+      TestNearest
+
+      Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
+    end
+
+    it "runs tests identified by 'Context'"
+      view +11 normal_test.go
+      TestNearest
+
+      Expect g:test#last_command == "ginkgo --focus='when the request is authenticated' ./."
+    end
+
+    it "runs tests identified by 'Describe'"
+      view +9 normal_test.go
+      TestNearest
+
+      Expect g:test#last_command == "ginkgo --focus='posts API' ./."
+    end
+
+  end
+
+  it "runs nearest tests in subdirectory"
+    view +17 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./mypackage"
+  end
+
+  it "runs file test if nearest test couldn't be found"
+    view +1 mypackage/normal_test.go
+    TestNearest
+    echo(g:test#last_command)
+    Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=mypackage/normal_test.go"
+  end
+
+  it "runs file tests"
+    view normal_test.go
+    TestFile
+
+    Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=normal_test.go"
+  end
+
+  it "runs tests in subdirectory"
+    view mypackage/normal_test.go
+    TestFile
+
+    Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=mypackage/normal_test.go"
+  end
+
+  it "runs test suites"
+    view normal_test.go
+    TestSuite
+
+    Expect g:test#last_command == "ginkgo ./..."
+  end
+
+end

--- a/spec/ginkgo_spec.vim
+++ b/spec/ginkgo_spec.vim
@@ -3,7 +3,6 @@ source spec/support/helpers.vim
 describe "Ginkgo"
 
   before
-    let g:test#go#runner = 'ginkgo'
     cd spec/fixtures/ginkgo
   end
 
@@ -12,22 +11,22 @@ describe "Ginkgo"
     cd -
   end
 
-  describe "runs nearest tests"
-    it "runs test identified by 'It'"
+  describe "TestNearest"
+    it "runs nearest test identified by 'It'"
       view +17 normal_test.go
       TestNearest
 
       Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
     end
 
-    it "runs tests identified by 'Context'"
+    it "runs nearest tests identified by 'Context'"
       view +11 normal_test.go
       TestNearest
 
       Expect g:test#last_command == "ginkgo --focus='when the request is authenticated' ./."
     end
 
-    it "runs tests identified by 'Describe'"
+    it "runs nearest tests identified by 'Describe'"
       view +9 normal_test.go
       TestNearest
 
@@ -68,6 +67,17 @@ describe "Ginkgo"
     TestSuite
 
     Expect g:test#last_command == "ginkgo ./..."
+  end
+
+  describe "when test#go#runner is set"
+    " make sure test#go#test_file doesn't have side-effect on cursor position
+    it "runs nearest test"
+      let g:test#go#runner = 'ginkgo'
+      view +17 normal_test.go
+      TestNearest
+
+      Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
+    end
   end
 
 end

--- a/spec/go_runner_spec.vim
+++ b/spec/go_runner_spec.vim
@@ -1,0 +1,38 @@
+source spec/support/helpers.vim
+
+describe "Go Runner"
+  before
+    cd spec/fixtures
+  end
+  
+  after
+    cd -
+  end
+
+  describe "when test#go#runner is not set"
+    after
+      call Teardown()
+    end
+    it "should use ginkgo if 'github.com/onsi/ginkgo' is found"
+      view ginkgo/normal_test.go
+      TestFile
+      Expect g:test#last_command =~# '\v^ginkgo'
+    end
+    it "should use gotest otherwise"
+      view gotest/normal_test.go
+      TestFile
+      Expect g:test#last_command =~# '\v^go test'
+    end
+  end
+
+  describe "when test#go#runner is set"
+    it "should respect test#go#runner"
+      for runner in ["ginkgo", "gotest"]
+        let g:test#go#runner = runner
+        Expect test#determine_runner("ginkgo/normal_test.go") == 'go#'.runner
+        Expect test#determine_runner("gotest/normal_test.go") == 'go#'.runner
+      endfor
+    end
+  end
+
+


### PR DESCRIPTION
[Ginkgo](https://github.com/onsi/ginkgo) is a BDD-style Golang testing framework.

Although Ginkgo tests can be run by `go test`, `gotest.vim` is unable to build positions because of its BDD style. `ginkgo.vim` builds positions based on BDD keywords offered by Ginkgo: `It`, `Describe` and `Context`.

For your reference, Ginkgo cli offers two ways to run a subset of tests:
* regex on spec: `ginkgo --focus="should return 0"`
* regex on test file path: `ginkgo --regexScansFilePath=true --focus=package/some_test.go`

I'm fairly new to vim-script. Any suggestion will be appreciated, Thanks!

