### PR TITLE
Detect the JavaScript runner based on the package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ can turn it off:
 let test#ruby#bundle_exec = 0
 ```
 
+#### JavaScript
+
+Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies.
+
 ## Extending
 
 If you wish to extend this plugin with your own test runners, first of all,

--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -4,7 +4,7 @@ let test#javascript#patterns = {
 \}
 
 function! test#javascript#has_package(package) abort
-  exec 'silent grep! 'a:package .' package.json'
+  exec "silent grep! '\b".a:package."\b' package.json"
 
   return len(getqflist()) > 0
 endfunction

--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -2,3 +2,9 @@ let test#javascript#patterns = {
   \ 'test': ['\v^\s*%(it|test)\s*[( ]\s*%("|'')(.*)%("|'')'],
   \ 'namespace': ['\v^\s*%(describe|suite|context)\s*[( ]\s*%("|'')(.*)%("|'')'],
 \}
+
+function! test#javascript#has_package(package) abort
+  exec 'silent grep! 'a:package .' package.json'
+
+  return len(getqflist()) > 0
+endfunction

--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -4,7 +4,11 @@ let test#javascript#patterns = {
 \}
 
 function! test#javascript#has_package(package) abort
-  exec "silent grep! '\b".a:package."\b' package.json"
+  for line in readfile("package.json")
+    if line =~ '"'.a:package.'"'
+      return 1
+    endif
+  endfor
 
-  return len(getqflist()) > 0
+  return 0
 endfunction

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -12,8 +12,8 @@ endif
 
 function! test#javascript#intern#test_file(file) abort
   return a:file =~# g:test#javascript#intern#file_pattern
-       \ && filereadable(g:test#javascript#intern#config_module . '.js')
-       \ && test#javascript#has_package('intern')
+    \ && filereadable(g:test#javascript#intern#config_module . '.js')
+    \ && (test#javascript#has_package('intern') || !empty(test#javascript#intern#executable()))
 endfunction
 
 function! test#javascript#intern#build_position(type, position) abort

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -13,6 +13,7 @@ endif
 function! test#javascript#intern#test_file(file) abort
   return a:file =~# g:test#javascript#intern#file_pattern
        \ && filereadable(g:test#javascript#intern#config_module . '.js')
+       \ && test#javascript#has_package('intern')
 endfunction
 
 function! test#javascript#intern#build_position(type, position) abort

--- a/autoload/test/javascript/jasmine.vim
+++ b/autoload/test/javascript/jasmine.vim
@@ -4,6 +4,7 @@ endif
 
 function! test#javascript#jasmine#test_file(file) abort
   return a:file =~? g:test#javascript#jasmine#file_pattern
+    && test#javascript#has_package('jasmine')
 endfunction
 
 function! test#javascript#jasmine#build_position(type, position) abort

--- a/autoload/test/javascript/jasmine.vim
+++ b/autoload/test/javascript/jasmine.vim
@@ -4,7 +4,7 @@ endif
 
 function! test#javascript#jasmine#test_file(file) abort
   return a:file =~? g:test#javascript#jasmine#file_pattern
-    && test#javascript#has_package('jasmine')
+	  \ && (test#javascript#has_package('jasmine') || !empty(test#javascript#jasmine#executable()))
 endfunction
 
 function! test#javascript#jasmine#build_position(type, position) abort

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#jest#file_pattern')
-  let g:test#javascript#jest#file_pattern = '(\v__tests__/.*.(js|jsx|coffee)|(\v.*(spec|test)\.(js|jsx|coffee))$'
+  let g:test#javascript#jest#file_pattern = '\v(__tests__/.*|(spec|test))\.(js|jsx|coffee)$'
 endif
 
 function! test#javascript#jest#test_file(file) abort

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#jest#file_pattern')
-  let g:test#javascript#jest#file_pattern = '\v(__tests__/.*|\.(test|spec))\.(js|jsx|coffee)$'
+  let g:test#javascript#jest#file_pattern = '(\v__tests__/.*.(js|jsx|coffee)|(\v.*(spec|test)\.(js|jsx|coffee))$'
 endif
 
 function! test#javascript#jest#test_file(file) abort

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -4,6 +4,7 @@ endif
 
 function! test#javascript#jest#test_file(file) abort
   return a:file =~# g:test#javascript#jest#file_pattern
+    && test#javascript#has_package('jest')
 endfunction
 
 function! test#javascript#jest#build_position(type, position) abort

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -4,7 +4,7 @@ endif
 
 function! test#javascript#jest#test_file(file) abort
   return a:file =~# g:test#javascript#jest#file_pattern
-    && test#javascript#has_package('jest')
+	  \ && (test#javascript#has_package('jest') || !empty(test#javascript#jest#executable()))
 endfunction
 
 function! test#javascript#jest#build_position(type, position) abort

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -8,6 +8,7 @@ function! test#javascript#karma#test_file(file) abort
   endif
 
   return a:file =~? g:test#javascript#karma#file_pattern
+    && test#javascript#has_package('karma')
 endfunction
 
 function! test#javascript#karma#build_position(type, position) abort

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -3,12 +3,8 @@ if !exists('g:test#javascript#karma#file_pattern')
 endif
 
 function! test#javascript#karma#test_file(file) abort
-  if empty(test#javascript#karma#executable())
-    return 0
-  endif
-
   return a:file =~? g:test#javascript#karma#file_pattern
-    && test#javascript#has_package('karma')
+	  \ && (test#javascript#has_package('karma') || !empty(test#javascript#karma#executable()))
 endfunction
 
 function! test#javascript#karma#build_position(type, position) abort

--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -4,6 +4,7 @@ endif
 
 function! test#javascript#mocha#test_file(file) abort
   return a:file =~# g:test#javascript#mocha#file_pattern
+	&& test#javascript#has_package('mocha')
 endfunction
 
 function! test#javascript#mocha#build_position(type, position) abort

--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -4,7 +4,7 @@ endif
 
 function! test#javascript#mocha#test_file(file) abort
   return a:file =~# g:test#javascript#mocha#file_pattern
-	&& test#javascript#has_package('mocha')
+	  \ && (test#javascript#has_package('mocha') || !empty(test#javascript#mocha#executable()))
 endfunction
 
 function! test#javascript#mocha#build_position(type, position) abort

--- a/autoload/test/javascript/tap.vim
+++ b/autoload/test/javascript/tap.vim
@@ -11,8 +11,7 @@ if !exists('g:test#javascript#tap#reporters')
 endif
 
 function! test#javascript#tap#test_file(file) abort
-  return !empty(test#javascript#tap#executable())
-    && a:file =~# g:test#javascript#tap#file_pattern
+  return !empty(test#javascript#tap#executable()) && a:file =~# g:test#javascript#tap#file_pattern
 endfunction
 
 function! test#javascript#tap#build_position(type, position) abort

--- a/autoload/test/javascript/tap.vim
+++ b/autoload/test/javascript/tap.vim
@@ -11,7 +11,8 @@ if !exists('g:test#javascript#tap#reporters')
 endif
 
 function! test#javascript#tap#test_file(file) abort
-  return !empty(test#javascript#tap#executable()) && a:file =~# g:test#javascript#tap#file_pattern
+  return !empty(test#javascript#tap#executable())
+    && a:file =~# g:test#javascript#tap#file_pattern
 endfunction
 
 function! test#javascript#tap#build_position(type, position) abort

--- a/spec/fixtures/intern/package.json
+++ b/spec/fixtures/intern/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "intern": "^3.4.3"
+  }
+}

--- a/spec/fixtures/jasmine/package.json
+++ b/spec/fixtures/jasmine/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "jasmine": "^2.6.0"
+  }
+}

--- a/spec/fixtures/jest/package.json
+++ b/spec/fixtures/jest/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "jest": "^20.0.0"
+  }
+}

--- a/spec/fixtures/karma/package.json
+++ b/spec/fixtures/karma/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "karma": "^1.7.0"
+  }
+}

--- a/spec/fixtures/lab/package.json
+++ b/spec/fixtures/lab/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "lab": "^13.0.4"
+  }
+}

--- a/spec/fixtures/mocha/package.json
+++ b/spec/fixtures/mocha/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "mocha": "^3.3.0"
+  }
+}

--- a/spec/fixtures/tap/package.json
+++ b/spec/fixtures/tap/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "tap": "^10.3.2"
+  }
+}

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -103,11 +103,11 @@ describe "Jest"
     Expect g:test#last_command == 'jest'
   end
 
-  it "doesn't detect JavaScripts which are not in the __tests__/ folder"
+  it "runs tests outside of __tests__"
     view outside-test.js
-    TestSuite
+    TestFile
 
-    Expect exists('g:test#last_command') == 0
+    Expect g:test#last_command == 'jest outside-test.js'
   end
 
 end


### PR DESCRIPTION
This arises for #187 as based on this plugin's motto of zero configuration we should try to infer the runner from the package.json

![](http://68.media.tumblr.com/67aacfed7bcf3cb71615e112e153156b/tumblr_opo4m67GlO1v1l4cbo1_540.gif)