### PR TITLE
FIX better support for options in maventest

### DIFF
--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -24,7 +24,7 @@ function! test#java#maventest#build_position(type, position) abort
 endfunction
 
 function! test#java#maventest#build_args(args) abort
-    return a:args
+  return a:args
 endfunction
 
 function! test#java#maventest#executable() abort

--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -6,26 +6,26 @@ function! test#java#maventest#test_file(file) abort
   return a:file =~? g:test#java#maventest#file_pattern
 endfunction
 
+
 function! test#java#maventest#build_position(type, position) abort
   let filename = fnamemodify(a:position['file'], ':t:r')
 
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      return [name]
+      return ['-Dtest=' . name]
     else
-      return [filename]
+      return ['-Dtest=' . filename]
     endif
   elseif a:type == 'file'
-    return [filename]
+    return ['-Dtest=' . filename]
   else
     return []
   endif
 endfunction
 
 function! test#java#maventest#build_args(args) abort
-  let args = ['-Dtest='] + a:args
-  return [join(args, "")]
+    return a:args
 endfunction
 
 function! test#java#maventest#executable() abort

--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -6,7 +6,6 @@ function! test#java#maventest#test_file(file) abort
   return a:file =~? g:test#java#maventest#file_pattern
 endfunction
 
-
 function! test#java#maventest#build_position(type, position) abort
   let filename = fnamemodify(a:position['file'], ':t:r')
 

--- a/spec/maventest_spec.vim
+++ b/spec/maventest_spec.vim
@@ -7,7 +7,6 @@ describe "Maven"
   end
 
   after
-    unlet! g:test#java#maventest#options
     call Teardown()
     cd -
   end
@@ -21,8 +20,7 @@ describe "Maven"
 
   it "runs file tests with user provided options"
     view MathTest.java
-    let g:test#java#maventest#options = '-f pom.xml'
-    TestFile
+    TestFile -f pom.xml
 
     Expect g:test#last_command == 'mvn test -f pom.xml -Dtest=MathTest'
   end
@@ -43,8 +41,7 @@ describe "Maven"
 
   it "runs a test suite with user provided options"
     view MathTest.java
-    let g:test#java#maventest#options = '-X -f pom.xml -DcustomProperty=5'
-    TestSuite
+    TestSuite -X -f pom.xml -DcustomProperty=5
 
     Expect g:test#last_command == 'mvn test -X -f pom.xml -DcustomProperty=5'
   end

--- a/spec/maventest_spec.vim
+++ b/spec/maventest_spec.vim
@@ -7,6 +7,7 @@ describe "Maven"
   end
 
   after
+    unlet! g:test#java#maventest#options
     call Teardown()
     cd -
   end
@@ -18,11 +19,34 @@ describe "Maven"
     Expect g:test#last_command == 'mvn test -Dtest=MathTest'
   end
 
+  it "runs file tests with user provided options"
+    view MathTest.java
+    let g:test#java#maventest#options = '-f pom.xml'
+    TestFile
+
+    Expect g:test#last_command == 'mvn test -f pom.xml -Dtest=MathTest'
+  end
+
   it "runs nearest tests"
     view +37 MathTest.java
     TestNearest
 
     Expect g:test#last_command == "mvn test -Dtest=MathTest\\#testFailedAdd"
+  end
+
+  it "runs a suite"
+    view MathTest.java
+    TestSuite
+
+    Expect g:test#last_command == 'mvn test'
+  end
+
+  it "runs a test suite with user provided options"
+    view MathTest.java
+    let g:test#java#maventest#options = '-X -f pom.xml -DcustomProperty=5'
+    TestSuite
+
+    Expect g:test#last_command == 'mvn test -X -f pom.xml -DcustomProperty=5'
   end
 
 end


### PR DESCRIPTION
maventest.vim could not support the vim-test way of adding options for a test
runner. For example if a user tried to pass `-f /path/to/pom.xml` as an option
parameter as follows:

`let test#java#maventest#options = '-f /path/to/pom.xml'`

the script would end up calling

`mvn test -Dtest=-f /path/to/pom.xml TestFileName`

which cannot work. Corrected the argument handling to support any number of
option parameters. The assumption is that 0 to 1 test names are passed to the
plugin. The example above now results to:

`mvn test -f /path/to/pom.xml -Dtest=TestFileName`

Fixes #194 