### PR TITLE
Fix readme formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ force a specific runner:
 ``` vim
 let test#go#runner = 'ginkgo'
 " Runners available are 'gotest', 'ginkgo'
+```
 
 #### Ruby
 


### PR DESCRIPTION
Go code example for specific runner was missing
3 ticks which bugged the whole ruby paragraph.

Fixed by adding back the 3 ticks to the vim example.