### PR TITLE
Let test be in front or at the end.

### DIFF
--- a/autoload/test/python/pytest.vim
+++ b/autoload/test/python/pytest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#python#pytest#file_pattern')
-  let g:test#python#pytest#file_pattern = '^test.*\.py$'
+  let g:test#python#pytest#file_pattern = '\v(^|[\b_\.-])test.*\.py$'
 endif
 
 function! test#python#pytest#test_file(file) abort


### PR DESCRIPTION
As stated [here](https://pytest.readthedocs.io/en/reorganize-docs/new-docs/user/naming_conventions.html).

Taken as reference [the nose modification](https://github.com/janko-m/vim-test/pull/32/files)