### PR TITLE
Add initial support for Elm and elm-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently the following testing frameworks are supported:
 | **Clojure**    | Fireplace.vim                                         | `fireplacetest`                                                   |
 | **Crystal**    | Crystal                                               | `crystalspec`                                                     |
 | **Elixir**     | ESpec, ExUnit                                         | `espec`, `exunit`                                                 |
+| **Elm**        | elm-test                                              | `elmtest`                                                         |
 | **Erlang**     | CommonTest                                            | `commontest`                                                      |
 | **Go**         | Ginkgo, Go                                            | `ginkgo`, `gotest`                                                |
 | **Java**       | Maven                                                 | `maventest`                                                       |

--- a/autoload/test/elm/elmtest.vim
+++ b/autoload/test/elm/elmtest.vim
@@ -1,0 +1,30 @@
+
+if !exists('g:test#elm#elmtest#file_pattern')
+  let g:test#elm#elmtest#file_pattern = '\vtests?\/.*\.elm$'
+endif
+
+function! test#elm#elmtest#test_file(file) abort
+  return a:file =~# g:test#elm#elmtest#file_pattern
+endfunction
+
+function! test#elm#elmtest#build_position(type, position) abort
+  if a:type ==# 'nearest'
+    " The test file must be modified to use `only` to only run a single test
+    " or group of tests (see
+    " https://github.com/elm-community/elm-test#not-running-tests), so just
+    " run the file and leave narrowing things down up to the user.
+    return [a:position['file']]
+  elseif a:type ==# 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#elm#elmtest#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#elm#elmtest#executable() abort
+  return 'elm-test'
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -114,6 +114,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:PyUnit*
 :PyUnit [args]               Uses the `unittest` `test` command.
 
+                                                *test-:ElmTest*
+:ElmTest [args]              Uses the `elm-test` command.
+
                                                 *test-:ExUnit*
 :ExUnit [args]               Uses the `mix` `test` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -17,6 +17,7 @@ call s:extend(g:test#runners, {
   \ 'JavaScript': ['Intern', 'TAP', 'Karma', 'Lab', 'Mocha', 'Jasmine', 'Jest'],
   \ 'Python':     ['DjangoTest', 'PyTest', 'PyUnit', 'Nose', 'Nose2'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
+  \ 'Elm':        ['ElmTest'],
   \ 'Erlang':     ['CommonTest'],
   \ 'Go':         ['GoTest', 'Ginkgo'],
   \ 'Rust':       ['CargoTest'],

--- a/spec/elmtest_spec.vim
+++ b/spec/elmtest_spec.vim
@@ -1,0 +1,34 @@
+source spec/support/helpers.vim
+
+describe "elm-test"
+  before
+    cd spec/fixtures/elmtest
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs file for nearest tests"
+    view tests/NormalTest.elm
+    TestNearest
+
+    Expect g:test#last_command == 'elm-test tests/NormalTest.elm'
+  end
+
+  it "runs file tests"
+    view tests/NormalTest.elm
+    TestFile
+
+    Expect g:test#last_command == 'elm-test tests/NormalTest.elm'
+  end
+
+  it "runs test suites"
+    view tests/NormalTest.elm
+    TestSuite
+
+    Expect g:test#last_command == 'elm-test'
+  end
+
+end

--- a/spec/fixtures/elmtest/tests/NormalTest.elm
+++ b/spec/fixtures/elmtest/tests/NormalTest.elm
@@ -1,0 +1,13 @@
+module NormalTest exposing (..)
+
+import Expect exposing (Expectation)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Testing things"
+        [ test "equality works" <|
+            \_ ->
+                Expect.equal "something" "something"
+        ]


### PR DESCRIPTION
This PR adds initial basic support for [Elm](http://elm-lang.org/) and [elm-test](https://github.com/elm-community/elm-test) to vim-test. Thanks :slightly_smiling_face: