### PR TITLE
Add support for swift test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently the following testing frameworks are supported:
 | **Ruby**       | Cucumber, [M], [Minitest][minitest], Rails, RSpec     | `cucumber`, `m`, `minitest`, `rails`, `rspec`                     |
 | **Rust**       | Cargo                                                 | `cargotest`                                                       |
 | **Shell**      | Bats                                                  | `bats`                                                            |
+| **Swift**      | Swift Package Manager                                 | `swiftpm`                                                         |
 | **VimScript**  | Vader.vim, VSpec                                      | `vader`, `vspec`                                                  |
 
 ## Features

--- a/autoload/test/swift.vim
+++ b/autoload/test/swift.vim
@@ -1,0 +1,5 @@
+let g:test#swift#patterns = {
+  \ 'test':      ['\v^\s*func (test.*)\(\)'],
+  \ 'namespace': ['\v^class ([-_a-zA-Z0-9]+): XCTestCase'],
+  \ 'module':    ['\v^Tests\/([-_ a-zA-Z0-9]+)\/']
+\}

--- a/autoload/test/swift/swiftpm.vim
+++ b/autoload/test/swift/swiftpm.vim
@@ -1,0 +1,67 @@
+if !exists('g:test#swift#swiftpm#file_pattern')
+  let g:test#swift#swiftpm#file_pattern = '\v^Tests\/.*\.swift$'
+endif
+
+function! test#swift#swiftpm#test_file(file) abort
+  return a:file =~# g:test#swift#swiftpm#file_pattern
+endfunction
+
+function! test#swift#swiftpm#build_position(type, position) abort
+  if a:type ==# 'nearest'
+    let l:module = s:parse_module_info(a:position)
+    let l:testcase = s:parse_case_info(a:position)
+    let l:nearest = s:parse_nearest_test_info(a:position)
+    return ['--specifier', l:module . '.' . l:testcase . '/' . l:nearest]
+  elseif a:type ==# 'file'
+    let l:module = s:parse_module_info(a:position)
+    let l:testcase = s:parse_case_info(a:position)
+    return ['--specifier', l:module . '.' . l:testcase]
+  else
+    return []
+  endif
+endfunction
+
+function! test#swift#swiftpm#build_args(args) abort
+  return a:args
+endfunction
+
+function test#swift#swiftpm#executable() abort
+  return 'swift test'
+endfunction
+
+function! s:parse_module_info(position)
+  return s:get_first_match(a:position['file'], g:test#swift#patterns['module'])
+endfunction
+
+function! s:parse_case_info(position)
+  let l:result = ""
+
+  for l:line in getbufline(a:position['file'], 1, '$')
+    let l:match = s:get_first_match(l:line, g:test#swift#patterns['namespace'])
+    if strlen(l:match) > 0
+      let l:result = l:match
+      break
+    endif
+  endfor
+
+  return l:result
+endfunction
+
+function! s:parse_nearest_test_info(position)
+  let l:info = test#base#nearest_test(a:position, g:test#swift#patterns)
+  return join(l:info['test'])
+endfunction
+
+function! s:get_first_match(source, patterns)
+  let l:result = ""
+
+  for l:pattern in a:patterns
+    let l:matches = matchlist(a:source, pattern)
+    if len(l:matches) > 1
+      let l:result = l:matches[1]
+      break
+    endif
+  endfor
+
+  return l:result
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -176,6 +176,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:CrystalSpec*
 :CrystalSpec [args]          Uses the `crystal` `spec` command.
 
+                                                *test-:SwiftPM*
+:SwiftPM [args]              Uses the `swift test` command.
+
 STRATEGIES                                      *test-strategies*
 
 Multiple strategies are supported for running tests.

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -23,6 +23,7 @@ call s:extend(g:test#runners, {
   \ 'Clojure':    ['FireplaceTest'],
   \ 'CSharp':     ['DotnetTest'],
   \ 'Shell':      ['Bats'],
+  \ 'Swift':      ['SwiftPM'],
   \ 'VimL':       ['VSpec', 'Vader'],
   \ 'Lua':        ['Busted'],
   \ 'PHP':        ['Codeception', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],

--- a/spec/fixtures/swiftpm/Package.swift
+++ b/spec/fixtures/swiftpm/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:3.1
+
+import PackageDescription
+
+let package = Package(
+    name: "VimTest"
+)

--- a/spec/fixtures/swiftpm/Sources/VimTest.swift
+++ b/spec/fixtures/swiftpm/Sources/VimTest.swift
@@ -1,0 +1,3 @@
+struct VimTest {
+  let text = "Hello, World!"
+}

--- a/spec/fixtures/swiftpm/Tests/LinuxMain.swift
+++ b/spec/fixtures/swiftpm/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import VimTestTests
+
+XCTMain([
+    testCase(VimTestTests.allTests),
+])

--- a/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestTests.swift
+++ b/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import VimTest
+
+class VimTestTests: XCTestCase {
+  func testExample() {
+    XCTAssertEqual(VimTest().text, "Hello, World!")
+  }
+
+  func testOther() {
+    XCTAssertEqual(true, true)
+  }
+
+  static var allTests = [
+    ("testExample", testExample),
+    ("testOther", testOther)
+  ]
+}

--- a/spec/swiftpm_spec.vim
+++ b/spec/swiftpm_spec.vim
@@ -1,0 +1,38 @@
+source spec/support/helpers.vim
+
+describe "SwiftPM"
+
+  before
+    cd spec/fixtures/swiftpm/
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +6 Tests/VimTestTests/VimTestTests.swift
+    TestNearest
+    Expect g:test#last_command == 'swift test --specifier VimTestTests.VimTestTests/testExample'
+
+    view +10 Tests/VimTestTests/VimTestTests.swift
+    TestNearest
+    Expect g:test#last_command == 'swift test --specifier VimTestTests.VimTestTests/testOther'
+  end
+
+  it "runs file tests"
+    view Tests/VimTestTests/VimTestTests.swift
+    TestFile
+
+    Expect g:test#last_command == 'swift test --specifier VimTestTests.VimTestTests'
+  end
+
+  it "runs test suites"
+    view Tests/VimTestTests/VimTestTests.swift
+    TestSuite
+
+    Expect g:test#last_command == 'swift test'
+  end
+
+end


### PR DESCRIPTION
Swift Package Manager ships a test runner that is accessible via `swift test`.
This commit adds support for working with `swift test` via vim-test.

There's definitely some fragility in here still that might need to get worked
out over time. Off the top of my head, some potential issues:

- Users might locate their tests in a directory named something other than
  "Tests". Doing so would break the test file detection (and the module name
  parsing).
- If users use a test lib like Quick, this won't properly parse module info
  (and filtering Quick tests with swift test doesn't work at all).

That being said, I think this is a good start, and getting this into the
plugin would mean being able to deploy fixes for these issues by tweaking the
regexes instead of needing to write this whole thing from scratch.