### PR TITLE
Option to turn Ruby binstubs off if they exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,12 @@ can turn it off:
 let test#ruby#bundle_exec = 0
 ```
 
+If binstubs are detected, but you don't want to use them, you can turn them off:
+
+```vim
+let test#ruby#use_binstubs = 0
+```
+
 #### JavaScript
 
 Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies.

--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -31,7 +31,7 @@ endfunction
 function! test#ruby#cucumber#executable() abort
   if !empty(glob('.zeus.sock'))
     return 'zeus cucumber'
-  elseif filereadable('./bin/cucumber')
+  elseif filereadable('./bin/cucumber') && get(g:, 'test#ruby#use_binstubs', 1)
     return './bin/cucumber'
   elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)
     return 'bundle exec cucumber'

--- a/autoload/test/ruby/m.vim
+++ b/autoload/test/ruby/m.vim
@@ -23,7 +23,7 @@ endfunction
 function! test#ruby#m#executable() abort
   if !empty(glob('.zeus.sock'))
     return 'zeus m'
-  elseif filereadable('./bin/m')
+  elseif filereadable('./bin/m') && get(g:, 'test#ruby#use_binstubs', 1)
     return './bin/m'
   elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)
     return 'bundle exec m'

--- a/autoload/test/ruby/minitest.vim
+++ b/autoload/test/ruby/minitest.vim
@@ -67,7 +67,7 @@ function! test#ruby#minitest#executable() abort
    \ (exists('b:rails_root') || filereadable('./bin/rails'))
     if !empty(glob('.zeus.sock'))
       return 'zeus rake test'
-    elseif filereadable('./bin/rake')
+    elseif filereadable('./bin/rake') && get(g:, 'test#ruby#use_binstubs', 1)
       return './bin/rake test'
     elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)
       return 'bundle exec rake test'

--- a/autoload/test/ruby/rails.vim
+++ b/autoload/test/ruby/rails.vim
@@ -27,7 +27,7 @@ endfunction
 function! test#ruby#rails#executable() abort
   if !empty(glob('.zeus.sock'))
     return 'zeus rails test'
-  elseif filereadable('./bin/rails')
+  elseif filereadable('./bin/rails') && get(g:, 'test#ruby#use_binstubs', 1)
     return './bin/rails test'
   elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)
     return 'bundle exec rails test'

--- a/autoload/test/ruby/rspec.vim
+++ b/autoload/test/ruby/rspec.vim
@@ -29,7 +29,7 @@ endfunction
 function! test#ruby#rspec#executable() abort
   if !empty(glob('.zeus.sock'))
     return 'zeus rspec'
-  elseif filereadable('./bin/rspec')
+  elseif filereadable('./bin/rspec') && get(g:, 'test#ruby#use_binstubs', 1)
     return './bin/rspec'
   elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)
     return 'bundle exec rspec'


### PR DESCRIPTION
This pull request adds an option `test#ruby#use_binstubs` (defaults to 1/true) to allow users to configure vim-test to ignore any binstubs that may exist.

Sometimes you're working on a project and have no control over whether there are binstubs in the directory, but you don't want to (or can't) use them. This adds an option so they get ignored.