### PR TITLE
Make maventest match all surefire filename patterns (janko-m/vim-test#206)

### DIFF
--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#java#maventest#file_pattern')
-  let g:test#java#maventest#file_pattern = '\v^.*[Tt]est\.java$'
+  let g:test#java#maventest#file_pattern = '\v^([Tt]est.*|.*[Tt]est(s|Case)?)\.java$'
 endif
 
 function! test#java#maventest#test_file(file) abort

--- a/spec/fixtures/maven/MathTestCase.java
+++ b/spec/fixtures/maven/MathTestCase.java
@@ -1,0 +1,46 @@
+package org.vimtest.math;
+
+import org.vimtest.calc.Calculation;
+
+import junit.framework.TestCase;
+
+public class MathTestCase extends TestCase {
+
+	private int value1;
+
+	private int value2;
+
+	public MathTestCase(String testName) {
+		super(testName);
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		value1 = 3;
+		value2 = 5;
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		value1 = 0;
+		value2 = 0;
+	}
+
+	public void testAdd() {
+		int total = 8;
+		int sum = Calculation.add(value1, value2);
+		assertEquals(sum, total);
+	}
+
+	public void testFailedAdd() {
+		int total = 9;
+		int sum = Calculation.add(value1, value2);
+		assertNotSame(sum, total);
+	}
+
+	public void testSub() {
+		int total = 0;
+		int sub = Calculation.sub(4, 4);
+		assertEquals(sub, total);
+	}
+}

--- a/spec/fixtures/maven/MathTests.java
+++ b/spec/fixtures/maven/MathTests.java
@@ -1,0 +1,46 @@
+package org.vimtest.math;
+
+import org.vimtest.calc.Calculation;
+
+import junit.framework.TestCase;
+
+public class MathTests extends TestCase {
+
+	private int value1;
+
+	private int value2;
+
+	public MathTests(String testName) {
+		super(testName);
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		value1 = 3;
+		value2 = 5;
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		value1 = 0;
+		value2 = 0;
+	}
+
+	public void testAdd() {
+		int total = 8;
+		int sum = Calculation.add(value1, value2);
+		assertEquals(sum, total);
+	}
+
+	public void testFailedAdd() {
+		int total = 9;
+		int sum = Calculation.add(value1, value2);
+		assertNotSame(sum, total);
+	}
+
+	public void testSub() {
+		int total = 0;
+		int sub = Calculation.sub(4, 4);
+		assertEquals(sub, total);
+	}
+}

--- a/spec/fixtures/maven/TestMath.java
+++ b/spec/fixtures/maven/TestMath.java
@@ -1,0 +1,46 @@
+package org.vimtest.math;
+
+import org.vimtest.calc.Calculation;
+
+import junit.framework.TestCase;
+
+public class TestMath extends TestCase {
+
+	private int value1;
+
+	private int value2;
+
+	public TestMath(String testName) {
+		super(testName);
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		value1 = 3;
+		value2 = 5;
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		value1 = 0;
+		value2 = 0;
+	}
+
+	public void testAdd() {
+		int total = 8;
+		int sum = Calculation.add(value1, value2);
+		assertEquals(sum, total);
+	}
+
+	public void testFailedAdd() {
+		int total = 9;
+		int sum = Calculation.add(value1, value2);
+		assertNotSame(sum, total);
+	}
+
+	public void testSub() {
+		int total = 0;
+		int sub = Calculation.sub(4, 4);
+		assertEquals(sub, total);
+	}
+}

--- a/spec/maventest_spec.vim
+++ b/spec/maventest_spec.vim
@@ -11,11 +11,32 @@ describe "Maven"
     cd -
   end
 
-  it "runs file tests"
+  it "runs file tests (filename matches Test*.java"
+    view TestMath.java
+    TestFile
+
+    Expect g:test#last_command == 'mvn test -Dtest=TestMath'
+  end
+
+  it "runs file tests (filename matches *Test.java)"
     view MathTest.java
     TestFile
 
     Expect g:test#last_command == 'mvn test -Dtest=MathTest'
+  end
+
+  it "runs file tests (filename matches *Tests.java)"
+    view MathTests.java
+    TestFile
+
+    Expect g:test#last_command == 'mvn test -Dtest=MathTests'
+  end
+
+  it "runs file tests (filename matches *TestCase.java)"
+    view MathTestCase.java
+    TestFile
+
+    Expect g:test#last_command == 'mvn test -Dtest=MathTestCase'
   end
 
   it "runs file tests with user provided options"


### PR DESCRIPTION
maventest should match all Maven Surefire test filename patterns.

```
Test*.java
*Test.java
*Tests.java
*TestCase.java
```

http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html

Fixes https://github.com/janko-m/vim-test/issues/206.