### PR TITLE
Improve mocha suite test running

### DIFF
--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -16,6 +16,9 @@ function! test#javascript#mocha#build_position(type, position) abort
     return [a:position['file'], name]
   elseif a:type == 'file'
     return [a:position['file']]
+  elseif a:type == 'suite'
+    let test_dir = get(filter(['test/', 'tests/'], 'isdirectory(v:val)'), 0)
+    return ['--recursive', test_dir]
   else
     return []
   endif

--- a/spec/mocha_spec.vim
+++ b/spec/mocha_spec.vim
@@ -100,7 +100,7 @@ describe "Mocha"
     view test/normal.js
     TestSuite
 
-    Expect g:test#last_command == 'mocha'
+    Expect g:test#last_command == 'mocha --recursive test/'
   end
 
   it "also recognizes tests/ directory"


### PR DESCRIPTION
Pulled out separately from the MochaWebpack branch I'm working on. I believe this better handles getting mocha to find all the files in a suite

recurses into sub dirs
tries both test and tests