### PR TITLE
Added Laravel Dusk runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,27 @@ A Vim wrapper for running tests on different granularities.
 
 Currently the following testing frameworks are supported:
 
-| Language       | Frameworks                                            | Identifiers                                                       |
-| :------------: | ----------------------------------------------------- | ----------------------------------------------------------------- |
-| **C#**         | .NET                                                  | `dotnettest`                                                      |
-| **Clojure**    | Fireplace.vim                                         | `fireplacetest`                                                   |
-| **Crystal**    | Crystal                                               | `crystalspec`                                                     |
-| **Elixir**     | ESpec, ExUnit                                         | `espec`, `exunit`                                                 |
-| **Elm**        | elm-test                                              | `elmtest`                                                         |
-| **Erlang**     | CommonTest                                            | `commontest`                                                      |
-| **Go**         | Ginkgo, Go                                            | `ginkgo`, `gotest`                                                |
-| **Java**       | Maven                                                 | `maventest`                                                       |
-| **JavaScript** | Intern, Jasmine, Jest, Karma, Lab, Mocha, TAP,        | `intern`, `jasmine`, `jest`, `karma`, `lab`, `mocha`, `tap`       |
-| **Lua**        | Busted                                                | `busted`                                                          |
-| **PHP**        | Behat, Codeception, Kahlan, Peridot, PHPUnit, PHPSpec | `behat`, `codeception`, `kahlan`, `peridot`, `phpunit`, `phpspec` |
-| **Perl**       | Prove                                                 | `prove`                                                           |
-| **Python**     | Django, Nose, Nose2, PyTest, PyUnit                   | `djangotest`, `djangonose` `nose`, `nose2`, `pytest`, `pyunit`    |
-| **Racket**     | RackUnit                                              | `rackunit`                                                        |
-| **Ruby**       | Cucumber, [M], [Minitest][minitest], Rails, RSpec     | `cucumber`, `m`, `minitest`, `rails`, `rspec`                     |
-| **Rust**       | Cargo                                                 | `cargotest`                                                       |
-| **Shell**      | Bats                                                  | `bats`                                                            |
-| **Swift**      | Swift Package Manager                                 | `swiftpm`                                                         |
-| **VimScript**  | Vader.vim, VSpec                                      | `vader`, `vspec`                                                  |
+| Language       | Frameworks                                            | Identifiers                                                               |
+| :------------: | ----------------------------------------------------- | ------------------------------------------------------------------------- |
+| **C#**         | .NET                                                  | `dotnettest`                                                              |
+| **Clojure**    | Fireplace.vim                                         | `fireplacetest`                                                           |
+| **Crystal**    | Crystal                                               | `crystalspec`                                                             |
+| **Elixir**     | ESpec, ExUnit                                         | `espec`, `exunit`                                                         |
+| **Elm**        | elm-test                                              | `elmtest`                                                                 |
+| **Erlang**     | CommonTest                                            | `commontest`                                                              |
+| **Go**         | Ginkgo, Go                                            | `ginkgo`, `gotest`                                                        |
+| **Java**       | Maven                                                 | `maventest`                                                               |
+| **JavaScript** | Intern, Jasmine, Jest, Karma, Lab, Mocha, TAP,        | `intern`, `jasmine`, `jest`, `karma`, `lab`, `mocha`, `tap`               |
+| **Lua**        | Busted                                                | `busted`                                                                  |
+| **PHP**        | Behat, Codeception, Kahlan, Peridot, PHPUnit, PHPSpec | `behat`, `codeception`, `kahlan`, `peridot`, `phpunit`, `phpspec`, `dusk` |
+| **Perl**       | Prove                                                 | `prove`                                                                   |
+| **Python**     | Django, Nose, Nose2, PyTest, PyUnit                   | `djangotest`, `djangonose` `nose`, `nose2`, `pytest`, `pyunit`            |
+| **Racket**     | RackUnit                                              | `rackunit`                                                                |
+| **Ruby**       | Cucumber, [M], [Minitest][minitest], Rails, RSpec     | `cucumber`, `m`, `minitest`, `rails`, `rspec`                             |
+| **Rust**       | Cargo                                                 | `cargotest`                                                               |
+| **Shell**      | Bats                                                  | `bats`                                                                    |
+| **Swift**      | Swift Package Manager                                 | `swiftpm`                                                                 |
+| **VimScript**  | Vader.vim, VSpec                                      | `vader`, `vspec`                                                          |
 
 ## Features
 

--- a/autoload/test/php/dusk.vim
+++ b/autoload/test/php/dusk.vim
@@ -1,0 +1,43 @@
+if !exists('g:test#php#dusk#file_pattern')
+  let g:test#php#dusk#file_pattern = '\v(t|T)est\.php$'
+endif
+
+function! test#php#dusk#test_file(file) abort
+  return a:file =~# g:test#php#dusk#file_pattern
+    \ && !empty(filter(readfile(a:file), 'v:val =~# ''use Laravel\\Dusk\\Browser'''))
+endfunction
+
+function! test#php#dusk#build_position(type, position) abort
+  if a:type == 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name) | let name = '--filter '.shellescape(name, 1) | endif
+    return [name, a:position['file']]
+  elseif a:type == 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#php#dusk#build_args(args) abort
+  let args = a:args
+
+  if !test#base#no_colors()
+    let args = ['--colors'] + args
+  endif
+
+  return args
+endfunction
+
+function! test#php#dusk#executable() abort
+  if filereadable('/usr/local/bin/php/artisan')
+    return './usr/local/bin/php/artisan dusk'
+  else
+    return 'php artisan dusk'
+  end
+endfunction
+
+function! s:nearest_test(position)
+  let name = test#base#nearest_test(a:position, g:test#php#patterns)
+  return join(name['test'])
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -158,6 +158,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:Behat*
 :Behat [args]                Uses the `behat` command.
 
+                                                *test-:Dusk*
+:Dusk [args]                 Uses the `dusk` command.
+
                                                 *test-:PHPSpec*
 :PHPSpec [args]              Uses the `phpspec` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -27,7 +27,7 @@ call s:extend(g:test#runners, {
   \ 'Swift':      ['SwiftPM'],
   \ 'VimL':       ['VSpec', 'Vader'],
   \ 'Lua':        ['Busted'],
-  \ 'PHP':        ['Codeception', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],
+  \ 'PHP':        ['Codeception', 'Dusk', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],
   \ 'Perl':       ['Prove'],
   \ 'Racket':     ['RackUnit'],
   \ 'Java':       ['MavenTest'],

--- a/spec/dusk_spec.vim
+++ b/spec/dusk_spec.vim
@@ -1,0 +1,42 @@
+source spec/support/helpers.vim
+
+describe "Dusk"
+
+  before
+    cd spec/fixtures/dusk
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view BrowserTest.php
+    TestFile
+
+    Expect g:test#last_command == 'php artisan dusk --colors BrowserTest.php'
+  end
+
+  it "runs nearest tests"
+    view +1 BrowserTest.php
+    TestNearest
+
+    Expect g:test#last_command == "php artisan dusk --colors BrowserTest.php"
+
+    view +10 BrowserTest.php
+    TestNearest
+
+    Expect g:test#last_command == "php artisan dusk --colors --filter 'testShouldAddTwoNumbers' BrowserTest.php"
+
+    view +15 BrowserTest.php
+    TestNearest
+
+    Expect g:test#last_command == "php artisan dusk --colors --filter 'testShouldSubtractTwoNumbers' BrowserTest.php"
+
+    view +31 BrowserTest.php
+    TestNearest
+
+    Expect g:test#last_command == "php artisan dusk --colors --filter 'testShouldAddToExpectedValue' BrowserTest.php"
+  end
+end

--- a/spec/fixtures/dusk/BrowserTest.php
+++ b/spec/fixtures/dusk/BrowserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests;
+
+use Laravel\Dusk\Browser;
+use PHPUnit_Framework_TestCase;
+
+class BrowserTest extends PHPUnit_Framework_TestCase
+{
+    public function testShouldAddTwoNumbers()
+    {
+        $this->assertEquals(2, 1+1);
+    }
+
+    public function testShouldSubtractTwoNumbers()
+    {
+        $this->assertEquals(2, 4-2);
+    }
+
+    public function additionProvider()
+    {
+        return [
+            [2, 4, 6],
+            [4, 2, 6]
+        ];
+    }
+
+    /**
+     * @dataProvider additionProvider
+     */
+    public function testShouldAddToExpectedValue($a, $b, $expected)
+    {
+        $this->assertEquals($expected, $a + $b);
+    }
+
+    /**
+     * @test
+     */
+    public function aTestMarkedWithTestAnnotation()
+    {
+        $this->assertEquals(2, 4-21);
+    }
+
+    /**
+     * Possible comments
+     *
+     * @someOtherAnnotation
+     * @test
+     * @param foo bar
+     */
+    public function aTestMarkedWithTestAnnotationAndCrazyDocblock()
+    {
+        $this->assertEquals(2, 4-21);
+    }
+}


### PR DESCRIPTION
Add Laravel Dusk tests to vim-test.

Implementation should be almost exactly similar to PhpUnit; tests should only run differently if `use Laravel\Dusk\Browser` exists in the file.

To avoid worrying about folder structure (that seemed a bit brittle to me), I just tested for the presence of 'use Laravel\Dusk\Browser' and put the Dusk test runner before PHPUnit's to ensure it ran first (since it's using the same file matching pattern).