### PR TITLE
Add Dispatch! background variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ let test#strategy = "dispatch"
 | **Basic**&nbsp;(default)        | `basic`     | Runs test commands with `:!`, which switches your Vim to the terminal.           |
 | **Make**                        | `make`      | Runs test commands with `:make`.                                                 |
 | **Neovim**                      | `neovim`    | Runs test commands with `:terminal`, which spawns a terminal inside your Neovim. |
-| **[Dispatch]**                  | `dispatch`  | Runs test commands with `:Dispatch`.                                             |
+| **[Dispatch]** **[Dispatch!]**  | `dispatch` `dispatch_background`  | Runs test commands with `:Dispatch` or `:Dispatch!`.       |
 | **[Vimux]**                     | `vimux`     | Runs test commands in a small tmux pane at the bottom of your terminal.          |
 | **[Tslime]**                    | `tslime`    | Runs test commands in a tmux pane you specify.                                   |
 | **[Neoterm]**                   | `neoterm`   | Runs test commands with `:T`, see neoterm docs for display customization.        |

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -36,6 +36,10 @@ function! test#strategy#dispatch(cmd) abort
   execute 'Dispatch '.a:cmd
 endfunction
 
+function! test#strategy#dispatch_background(cmd) abort
+  execute 'Dispatch! '.a:cmd
+endfunction
+
 function! test#strategy#vimproc(cmd) abort
   execute 'VimProcBang '.a:cmd
 endfunction


### PR DESCRIPTION
I see that we have [Dispatch](https://github.com/janko-m/vim-test/blob/master/autoload/test/strategy.vim#L35) strategy, but I would like to run test in background, so I added this dispatch_background strategy