### PR TITLE
Add regex to force only a single test to run

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -9,7 +9,7 @@ endfunction
 function! test#php#phpunit#build_position(type, position) abort
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
-    if !empty(name) | let name = '--filter '.shellescape(name, 1) | endif
+    if !empty(name) | let name = '--filter '.shellescape(name.'$', 1) | endif
     return [name, a:position['file']]
   elseif a:type == 'file'
     return [a:position['file']]

--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -9,7 +9,7 @@ endfunction
 function! test#php#phpunit#build_position(type, position) abort
   if a:type == 'nearest'
     let name = s:nearest_test(a:position)
-    if !empty(name) | let name = '--filter '.shellescape(name.'$', 1) | endif
+    if !empty(name) | let name = '--filter '.shellescape('::'.name.'$', 1) | endif
     return [name, a:position['file']]
   elseif a:type == 'file'
     return [a:position['file']]

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -27,29 +27,29 @@ describe "PHPUnit"
     view +9 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddTwoNumbers$' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter '::testShouldAddTwoNumbers$' NormalTest.php"
 
     view +14 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'testShouldSubtractTwoNumbers$' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter '::testShouldSubtractTwoNumbers$' NormalTest.php"
 
     view +30 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddToExpectedValue$' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter '::testShouldAddToExpectedValue$' NormalTest.php"
   end
 
   it  "runs nearest test marked with @test annotation"
     view +40 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotation$' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAnnotation$' NormalTest.php"
 
     view +50 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotationAndCrazyDocblock$' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAnnotationAndCrazyDocblock$' NormalTest.php"
   end
 
   it "runs test suites"

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -27,29 +27,29 @@ describe "PHPUnit"
     view +9 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddTwoNumbers' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddTwoNumbers$' NormalTest.php"
 
     view +14 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'testShouldSubtractTwoNumbers' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter 'testShouldSubtractTwoNumbers$' NormalTest.php"
 
     view +30 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddToExpectedValue' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter 'testShouldAddToExpectedValue$' NormalTest.php"
   end
 
   it  "runs nearest test marked with @test annotation"
     view +40 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotation' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotation$' NormalTest.php"
 
     view +50 NormalTest.php
     TestNearest
 
-    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotationAndCrazyDocblock' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter 'aTestMarkedWithTestAnnotationAndCrazyDocblock$' NormalTest.php"
   end
 
   it "runs test suites"


### PR DESCRIPTION
Sometimes, a test method is a bit too generic and you end running multiple tests instead of **just** the nearest test. Take the following methods for example: `testFoo`, `testFooBar`, `testFooBaz`. If you test nearest inside `testFoo` then you end up running all 3 of those methods. Since phpunit supports regex, this syntax prevents that from happening. I specifically ran into this when testing a fluent query builder that had a lot of `where` methods, such as `where`, `whereNull`, `whereNotNull`, etc.

I'd be more than willing to run a test to ensure that phpunit only runs 1 test (say by capturing the output of phpunit) I'd be down to write it, but I'm not familiar with vspec at all so I would need some direction!