### PR TITLE
Check Python test class namespace is prefixed with Test

### DIFF
--- a/autoload/test/python.vim
+++ b/autoload/test/python.vim
@@ -1,4 +1,4 @@
 let test#python#patterns = {
   \ 'test':      ['\v^\s*%(async )?def (test_\w+)'],
-  \ 'namespace': ['\v^\s*class (\w+)'],
+  \ 'namespace': ['\v^\s*class (Test\w+)'],
 \}

--- a/spec/fixtures/nose/test_method.py
+++ b/spec/fixtures/nose/test_method.py
@@ -1,2 +1,9 @@
 def test_numbers():
     assert 1 == 1
+
+def test_foo():
+    class CustomException(Exception):
+        pass
+    mocker.patch('some.module', side_effect=CustomException())
+
+    assert something

--- a/spec/pytest_spec.vim
+++ b/spec/pytest_spec.vim
@@ -27,6 +27,11 @@ describe "PyTest"
     TestNearest
 
     Expect g:test#last_command == 'py.test test_method.py::test_numbers'
+
+    view +6 test_method.py
+    TestNearest
+
+    Expect g:test#last_command == 'py.test test_method.py::test_foo'
   end
 
   it "runs file test if nearest test couldn't be found"


### PR DESCRIPTION
This addresses the bug reported in #232 