### PR TITLE
[Option 2] Option to Set Secondary Project Root for Docker Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,25 @@ different working directory for running tests:
 let test#project_root = "/path/to/your/project"
 ```
 
+#### Working with vim-tmux-runner and docker container
+
+If you are using vim-tmux-runner (vtr) dispatch strategy and targeting a tmux
+pane that runs a docker container, you might have an issue where your
+project in your container has different path from your host machine. In that
+case you coud use below to set the project root path used in your container.
+
+```vim
+let test#secondary_project_root = "/container-path/to/your/project"
+```
+
+If your target tmux pane is already open with your project root could just set
+as following. This will make your setup generic enough to work with various
+projects.
+
+```vim
+let test#secondary_project_root = "."
+```
+
 ### Language-specific
 
 #### Python

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -125,7 +125,7 @@ endfunction
 
 function! s:pretty_command(cmd) abort
   let clear = !s:Windows() ? 'clear' : 'cls'
-  let cd = 'cd ' . shellescape(getcwd())
+  let cd = s:cd_command()
   let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
   let separator = !s:Windows() ? '; ' : ' & '
 
@@ -136,8 +136,17 @@ function! s:pretty_command(cmd) abort
   endif
 endfunction
 
+function! s:cd_command() abort
+  if exists('g:test#secondary_project_root')
+    return 'cd ' . shellescape(get(g:, 'test#secondary_project_root'))
+  elseif exists('g:test#project_root')
+    return 'cd ' . shellescape(get(g:, 'test#project_root'))
+  else
+    return 'cd ' . shellescape(getcwd())
+endfunction
+
 function! s:command(cmd) abort
-  let cd = 'cd ' . shellescape(getcwd())
+  let cd = s:cd_command()
   let separator = !s:Windows() ? '; ' : ' & '
 
   return join([l:cd, a:cmd], l:separator)


### PR DESCRIPTION
I'm having an issue with my setup where I'm using `vtr` dispatch strategy and I'm targeting
a tmux pane that runs a docker container. My project path in the docker container is different from the one in my host machine. So whenever I'm executing a test, there is `cd getcwd()` that will
be called and it resulted with `no such file or directory`.

Here i'm introducing `test#secondary_project_root` setting which will be useful for a setup
that runs in docker environment which different project path.

I've added a function that determine which project directory to change to with following priority

1. secondary_project_root
2. project_root
3. cwd (current working directory)