### PR TITLE
Do Proper Checking for Tape

### DIFF
--- a/autoload/test/javascript/tap.vim
+++ b/autoload/test/javascript/tap.vim
@@ -11,7 +11,8 @@ if !exists('g:test#javascript#tap#reporters')
 endif
 
 function! test#javascript#tap#test_file(file) abort
-  return !empty(test#javascript#tap#executable()) && a:file =~# g:test#javascript#tap#file_pattern
+  return a:file =~# g:test#javascript#tap#file_pattern 
+        \ && test#javascript#has_package('tape')
 endfunction
 
 function! test#javascript#tap#build_position(type, position) abort

--- a/autoload/test/javascript/tap.vim
+++ b/autoload/test/javascript/tap.vim
@@ -12,7 +12,7 @@ endif
 
 function! test#javascript#tap#test_file(file) abort
   return a:file =~# g:test#javascript#tap#file_pattern 
-        \ && test#javascript#has_package('tape')
+        \ && test#javascript#has_package('tap')
 endfunction
 
 function! test#javascript#tap#build_position(type, position) abort


### PR DESCRIPTION
I work on a project that has a sub-dependency that has `tape` as a normal dependency vs a development dependency; thus making the original checker for `tape` think that it should use it over the top-most testing tool (that being mocha).

In other words, this avoids the blunt checking for testing tools and checks the the top-most project's approach.

This aims to use the same kind of detection that mocha does to counteract mis-defined projects like this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janko-m/vim-test/255)
<!-- Reviewable:end -->
