### PR TITLE
[Option 3] Remove Change Directory in Strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -125,22 +125,20 @@ endfunction
 
 function! s:pretty_command(cmd) abort
   let clear = !s:Windows() ? 'clear' : 'cls'
-  let cd = 'cd ' . shellescape(getcwd())
   let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
   let separator = !s:Windows() ? '; ' : ' & '
 
   if !get(g:, 'test#preserve_screen')
-    return join([l:clear, l:cd, l:echo, a:cmd], l:separator)
+    return join([l:clear, l:echo, a:cmd], l:separator)
   else
-    return join([l:cd, l:echo, a:cmd], l:separator)
+    return join([l:echo, a:cmd], l:separator)
   endif
 endfunction
 
 function! s:command(cmd) abort
-  let cd = 'cd ' . shellescape(getcwd())
   let separator = !s:Windows() ? '; ' : ' & '
 
-  return join([l:cd, a:cmd], l:separator)
+  return join([a:cmd], l:separator)
 endfunction
 
 function! s:Windows() abort


### PR DESCRIPTION
**Why we need this change?**

I'm having an issue with my setup where I'm using vtr dispatch strategy and I'm targeting
a tmux pane that runs a docker container. My project path in the docker container is different from the one in my host machine. So whenever I'm executing a test, there is cd getcwd() that will
be called and it resulted with no such file or directory.

**What has changed?**

I've removed the related code for changing to test directory in strategy file.