### PR TITLE
Move test strategies to the file with a proper name

### DIFF
--- a/spec/nose_spec.vim
+++ b/spec/nose_spec.vim
@@ -1,9 +1,5 @@
 source spec/support/helpers.vim
 
-function! test#shell(cmd, strategy) abort
-  let g:test#last_command = substitute(a:cmd, ' --doctest-tests', '', '')
-endfunction
-
 describe "Nose"
 
   before
@@ -20,22 +16,22 @@ describe "Nose"
     view +2 test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'nosetests test_class.py:TestNumbers.test_numbers'
+    Expect g:test#last_command == 'nosetests --doctest-tests test_class.py:TestNumbers.test_numbers'
 
     view +5 test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'nosetests test_class.py:TestSubclass'
+    Expect g:test#last_command == 'nosetests --doctest-tests test_class.py:TestSubclass'
 
     view +1 test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'nosetests test_class.py:TestNumbers'
+    Expect g:test#last_command == 'nosetests --doctest-tests test_class.py:TestNumbers'
 
     view +1 test_method.py
     TestNearest
 
-    Expect g:test#last_command == 'nosetests test_method.py:test_numbers'
+    Expect g:test#last_command == 'nosetests --doctest-tests test_method.py:test_numbers'
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -43,21 +39,21 @@ describe "Nose"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'nosetests test_method.py'
+    Expect g:test#last_command == 'nosetests --doctest-tests test_method.py'
   end
 
   it "runs file tests"
     view test_class.py
     TestFile
 
-    Expect g:test#last_command == 'nosetests test_class.py'
+    Expect g:test#last_command == 'nosetests --doctest-tests test_class.py'
   end
 
   it "runs test suites"
     view test_class.py
     TestSuite
 
-    Expect g:test#last_command == 'nosetests'
+    Expect g:test#last_command == 'nosetests --doctest-tests'
   end
 
 end

--- a/spec/strategy_spec.vim
+++ b/spec/strategy_spec.vim
@@ -1,6 +1,10 @@
 source spec/support/helpers.vim
 
 describe "strategy"
+  before
+    source spec/support/test/strategy.vim
+  end
+
   after
     call Teardown()
     unlet! g:test#strategy

--- a/spec/support/helpers.vim
+++ b/spec/support/helpers.vim
@@ -1,22 +1,7 @@
 let g:test#runner_commands = ['RSpec', 'Minitest', 'FireplaceTest', 'Prove']
 
 source plugin/test.vim
-
-" don't execute any shell commands
-function! test#strategy#basic(cmd)
-endfunction
-
-" don't execute any shell commands
-function! test#strategy#dispatch(cmd)
-endfunction
-
-" don't execute any shell commands
-function! test#strategy#neovim(cmd)
-endfunction
-
-" don't execute any VimScript commands
-function! test#strategy#vimscript(cmd)
-endfunction
+source spec/support/test/strategy.vim
 
 function! Teardown() abort
   bufdo! bdelete!

--- a/spec/support/test/strategy.vim
+++ b/spec/support/test/strategy.vim
@@ -1,0 +1,15 @@
+" don't execute any shell commands
+function! test#strategy#basic(cmd)
+endfunction
+
+" don't execute any shell commands
+function! test#strategy#dispatch(cmd)
+endfunction
+
+" don't execute any shell commands
+function! test#strategy#neovim(cmd)
+endfunction
+
+" don't execute any VimScript commands
+function! test#strategy#vimscript(cmd)
+endfunction


### PR DESCRIPTION
This PR fixes (I hope!) #263.

`From :h autoload`:
```
Using an autoload script 
                                                        autoload E746
This is introduced in the user manual, section 41.15.

Using a script in the "autoload" directory is simpler, but requires using
exactly the right file name.  A function that can be autoloaded has a name
like this: 

        :call filename#funcname()

When such a function is called, and it is not defined yet, Vim will search the
"autoload" directories in 'runtimepath' for a script file called
"filename.vim".  For example "~/.vim/autoload/filename.vim".  That file should
then define the function like this: 

        function filename#funcname()
           echo "Done!"
        endfunction

The file name and the name used before the # in the function must match
exactly, and the defined function must have the name exactly as it will be
called.
```