### PR TITLE
Support running the nearest test for the PhpSpec

### DIFF
--- a/autoload/test/php/phpspec.vim
+++ b/autoload/test/php/phpspec.vim
@@ -8,7 +8,9 @@ function! test#php#phpspec#test_file(file) abort
 endfunction
 
 function! test#php#phpspec#build_position(type, position) abort
-  if a:type ==# 'nearest' || a:type ==# 'file'
+  if a:type ==# 'nearest'
+    return [a:position['file'].':'.a:position['line']]
+  elseif a:type ==# 'file'
     return [a:position['file']]
   else
     return []

--- a/spec/phpspec_spec.vim
+++ b/spec/phpspec_spec.vim
@@ -19,10 +19,10 @@ describe "PHPSpec"
   end
 
   it "runs nearest tests"
-    view +1 NormalSpec.php
+    view +11 NormalSpec.php
     TestNearest
 
-    Expect g:test#last_command == 'phpspec run NormalSpec.php'
+    Expect g:test#last_command == 'phpspec run NormalSpec.php:11'
   end
 
   it "runs test suites"


### PR DESCRIPTION
PHPSpec allows to specify a line number to run only the specification defined on that line. See http://www.phpspec.net/en/stable/cookbook/console.html#run-command. So, it's better than nothing :). 