### PR TITLE
Add support for vim-themis

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently the following testing frameworks are supported:
 | **Rust**       | Cargo                                                            | `cargotest`                                                                       |
 | **Shell**      | Bats                                                             | `bats`                                                                            |
 | **Swift**      | Swift Package Manager                                            | `swiftpm`                                                                         |
-| **VimScript**  | Vader.vim, VSpec                                                 | `vader`, `vspec`                                                                  |
+| **VimScript**  | Vader.vim, VSpec, Themis                                         | `vader`, `vspec`, `themis`                                                        |
 
 ## Features
 

--- a/VimFlavor
+++ b/VimFlavor
@@ -1,2 +1,3 @@
 flavor 'tpope/vim-fireplace'
 flavor 'junegunn/vader.vim'
+flavor 'thinca/vim-themis'

--- a/autoload/test/viml/themis.vim
+++ b/autoload/test/viml/themis.vim
@@ -1,0 +1,28 @@
+if !exists('g:test#viml#themis#file_pattern')
+  let g:test#viml#themis#file_pattern = '\.vim$'
+endif
+
+if !exists('g:test#viml#themis#executable')
+  let g:test#viml#themis#executable = 'themis'
+endif
+
+function! test#viml#themis#test_file(file) abort
+  return a:file =~# g:test#viml#themis#file_pattern
+        \ && !empty(filter(readfile(a:file), 'v:val =~# ''\<themis#suite\s*('''))
+endfunction
+
+function! test#viml#themis#build_position(type, position) abort
+  if a:type == 'nearest' || a:type == 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#viml#themis#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#viml#themis#executable() abort
+  throw 'The `g:test#viml#themis#executable` variable needs to be set with the path to the "themis" executable'
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -164,6 +164,12 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:VSpec*
 :VSpec [args]                Uses the `vim-flavor` `test` command.
 
+                                                *test-:Vader*
+:Vader [args]                Uses the `vader#run()` vim function.
+
+                                                *test-:Themis*
+:Themis [args]               Uses the `themis` command.
+
                                                 *test-:Busted*
 :Busted [args]               Uses the `busted` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -25,7 +25,7 @@ call s:extend(g:test#runners, {
   \ 'CSharp':     ['Xunit', 'DotnetTest'],
   \ 'Shell':      ['Bats'],
   \ 'Swift':      ['SwiftPM'],
-  \ 'VimL':       ['VSpec', 'Vader'],
+  \ 'VimL':       ['VSpec', 'Vader', 'Themis'],
   \ 'Lua':        ['Busted'],
   \ 'PHP':        ['Codeception', 'Dusk', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],
   \ 'Perl':       ['Prove'],

--- a/spec/fixtures/themis/math.vim
+++ b/spec/fixtures/themis/math.vim
@@ -1,0 +1,10 @@
+let s:suite = themis#suite("math")
+let s:assert = themis#helper("assert")
+
+function! s:suite.addition() abort
+  call s:assert.equal(2, 1 + 1)
+endfunction
+
+function! s:suite.subtraction() abort
+  call s:assert.equal(0, 1 - 1)
+endfunction

--- a/spec/themis_spec.vim
+++ b/spec/themis_spec.vim
@@ -1,0 +1,45 @@
+source spec/support/helpers.vim
+runtime! plugin/vim-themis
+
+describe "Themis"
+
+  before
+    let g:test#viml#themis#executable = "/path/to/themis"
+    cd spec/fixtures/themis
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs file test for nearest"
+    view +2 math.vim
+    TestNearest
+    messages
+
+    Expect g:test#last_command == "/path/to/themis math.vim"
+  end
+
+  it "runs file tests"
+    view +2 math.vim
+    TestFile
+
+    Expect g:test#last_command == "/path/to/themis math.vim"
+  end
+
+  it "runs test suite"
+    view math.vim
+    TestSuite
+
+    Expect g:test#last_command == "/path/to/themis"
+  end
+
+  it "passes arguments before the file"
+    view +2 math.vim
+    TestFile --foo bar
+
+    Expect g:test#last_command == "/path/to/themis --foo bar math.vim"
+  end
+
+end


### PR DESCRIPTION
This adds the [`themis`](https://github.com/thinca/vim-themis) runner. I've punted on adding `nearest` support because it will be a little complicated, seeing as it will have to convert a line number to the surrounding themis test function name. For now it just runs the whole file for both `file` and `nearest`.