### PR TITLE
Put Themis before VSpec in runner ordering

### DIFF
--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -25,7 +25,7 @@ call s:extend(g:test#runners, {
   \ 'CSharp':     ['Xunit', 'DotnetTest'],
   \ 'Shell':      ['Bats'],
   \ 'Swift':      ['SwiftPM'],
-  \ 'VimL':       ['VSpec', 'Vader', 'Themis'],
+  \ 'VimL':       ['Themis', 'VSpec', 'Vader'],
   \ 'Lua':        ['Busted'],
   \ 'PHP':        ['Codeception', 'Dusk', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],
   \ 'Perl':       ['Prove'],


### PR DESCRIPTION
The VSpec `test_file` function trumps the Themis one, since they both
check the `.vim` extension. This puts `Themis` first, since it is a more
specific check.

This is a quick followup to https://github.com/janko-m/vim-test/pull/269. Sorry for the noise.