### PR TITLE
Support TypeScript for common JavaScript test frameworks

### DIFF
--- a/autoload/test/javascript/ava.vim
+++ b/autoload/test/javascript/ava.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#ava#file_pattern')
-  let g:test#javascript#ava#file_pattern = '\vtests?/.*\.(js|jsx|coffee)$'
+  let g:test#javascript#ava#file_pattern = '\vtests?/.*\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#ava#test_file(file) abort

--- a/autoload/test/javascript/jasmine.vim
+++ b/autoload/test/javascript/jasmine.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#jasmine#file_pattern')
-  let g:test#javascript#jasmine#file_pattern = '\v^spec/.*spec\.(js|jsx|coffee)$'
+  let g:test#javascript#jasmine#file_pattern = '\v^spec/.*spec\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#jasmine#test_file(file) abort

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#jest#file_pattern')
-  let g:test#javascript#jest#file_pattern = '\v(__tests__/.*|(spec|test))\.(js|jsx|coffee)$'
+  let g:test#javascript#jest#file_pattern = '\v(__tests__/.*|(spec|test))\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#jest#test_file(file) abort

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#karma#file_pattern')
-  let g:test#javascript#karma#file_pattern = '\v(test|spec)\.(js|jsx|coffee)$'
+  let g:test#javascript#karma#file_pattern = '\v(test|spec)\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#karma#test_file(file) abort

--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#mocha#file_pattern')
-  let g:test#javascript#mocha#file_pattern = '\vtests?/.*\.(js|jsx|coffee)$'
+  let g:test#javascript#mocha#file_pattern = '\vtests?/.*\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#mocha#test_file(file) abort


### PR DESCRIPTION
This partially addresses #209 

Many test frameworks have their own transpile step and use the `.ts`/`.tsx` files as inputs.