### PR TITLE
Improve argument order for jest named testing

### DIFF
--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#jest#file_pattern')
-  let g:test#javascript#jest#file_pattern = '\v(__tests__/.*|(spec|test))\.(js|jsx|coffee)$'
+  let g:test#javascript#jest#file_pattern = '\v(__tests__/.*|(spec|test))\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#jest#test_file(file) abort
@@ -13,9 +13,9 @@ function! test#javascript#jest#build_position(type, position) abort
     if !empty(name)
       let name = '-t '.shellescape(name, 1)
     endif
-    return [a:position['file'], name]
+    return [name, '--', a:position['file']]
   elseif a:type ==# 'file'
-    return [a:position['file']]
+    return ['--', a:position['file']]
   else
     return []
   endif

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -16,68 +16,68 @@ describe "Jest"
       view +1 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.js -t ''^Math'''
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.js'
 
       view +2 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.js -t ''^Math Addition'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.js'
 
       view +3 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.js -t ''^Math Addition adds two numbers$'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
     end
 
     it "aliases context to describe"
       view +1 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/context-test.js -t ''^Math'''
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/context-test.js'
 
       view +2 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/context-test.js -t ''^Math Addition'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/context-test.js'
 
       view +3 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/context-test.js -t ''^Math Addition adds two numbers$'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
     end
 
     it "runs CoffeeScript"
       view +1 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.coffee -t ''^Math'''
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.coffee'
 
       view +2 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.coffee -t ''^Math Addition'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.coffee'
 
       view +3 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.coffee -t ''^Math Addition adds two numbers$'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
     end
 
     it "runs React"
       view +1 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.jsx -t ''^Math'''
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.jsx'
 
       view +2 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.jsx -t ''^Math Addition'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.jsx'
 
       view +3 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest __tests__/normal-test.jsx -t ''^Math Addition adds two numbers$'''
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
     end
   end
 
@@ -86,14 +86,14 @@ describe "Jest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'jest __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest -- __tests__/normal-test.js'
   end
 
   it "runs file tests"
     view __tests__/normal-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest -- __tests__/normal-test.js'
   end
 
   it "runs test suites"
@@ -107,7 +107,7 @@ describe "Jest"
     view outside-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest outside-test.js'
+    Expect g:test#last_command == 'jest -- outside-test.js'
   end
 
 end


### PR DESCRIPTION
The original order would run something like

```
jest $FILE -t $NAME
```

With custom options, this can cause issues. For example:

```
# let g:test#javascript#jest#options = '--reporters some-reporter'
jest --reporters some-reporter $FILE
```

jest attempt to use a reporter that matches the test filename.

This change uses the `--` before the input files to make them work
properly with custom and derived arguments.

```
jest --reporters some-reporter -t $NAME -- $FILE
```