### PR TITLE
Add Vim8 terminal strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ let test#strategy = "dispatch"
 | **Basic**&nbsp;(default)        | `basic`                          | Runs test commands with `:!` on Vim, and with `:terminal` on Neovim.             |
 | **Make**                        | `make`                           | Runs test commands with `:make`.                                                 |
 | **Neovim**                      | `neovim`                         | Runs test commands with `:terminal` in a split window.                           |
+| **Vim8 Terminal**               | `vimterminal`                    | Runs test commands with `:terminal` in a split window.                           |
 | **[Dispatch]**                  | `dispatch` `dispatch_background` | Runs test commands with `:Dispatch` or `:Dispatch!`.                             |
 | **[Vimux]**                     | `vimux`                          | Runs test commands in a small tmux pane at the bottom of your terminal.          |
 | **[Tslime]**                    | `tslime`                         | Runs test commands in a tmux pane you specify.                                   |

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -51,6 +51,11 @@ function! test#strategy#neovim(cmd) abort
   startinsert
 endfunction
 
+function! test#strategy#vimterminal(cmd) abort
+  botright new
+  call term_start(['/bin/sh', '-c', a:cmd], {'curwin':1})
+endfunction
+
 function! test#strategy#neoterm(cmd) abort
   call neoterm#do(a:cmd)
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -248,6 +248,12 @@ Runs test commands with `:terminal`, which spawns a terminal inside your Neovim.
 >
   let test#strategy = 'neovim'
 <
+Vim8 Terminal ~
+
+Runs test commands with `:terminal`, which spawns a terminal inside you Vim.
+>
+  let test#strategy = 'vimterminal'
+<
 Neoterm ~
 
 Runs test commands with `:T`. Requires the Neoterm plugin.


### PR DESCRIPTION
This adds a `vimterminal` strategy which uses the Vim8/MacVim terminal.  

Relates to #282 