### PR TITLE
Add an option to disable alternate file integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,11 @@ If [projectionist.vim] is present, you can run a test command from an
 application file, and test.vim will automatically try to run the
 command on the "alternate" test file.
 
+You can disable this integration by doing
+```vim
+let g:test_no_alternate = 1
+```
+
 ## Extending
 
 If you wish to extend this plugin with your own test runners, first of all,

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -127,6 +127,7 @@ function! test#test_file(file) abort
 endfunction
 
 function! s:alternate_file() abort
+  if get(g:, 'test_no_alternate') | return '' | endif
   let alternate_file = ''
 
   if empty(alternate_file) && exists('g:loaded_projectionist')

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -428,6 +428,10 @@ If the |projectionist| plug-in is present, you can run a test command from an
 application file, and test.vim will automatically try to run the
 command on the "alternate" test file.
 
+You can disable this integration by doing
+>
+  let g:test_no_alternate = 1
+<
 ABOUT                                           *test-about*
 
 You can get the latest version, see the changelog, or report a bug on GitHub:


### PR DESCRIPTION
This PR adds an option to disable alternate file integration.

There are a few reasons why I don't like alternate file integration. One of them is that I use heavily lazy-loaded and customized versions of vim-rails and projectionist to boost vim start-up times. Which makes vim-test bug, and since it is an independent plugin, it should not.