### PR TITLE
jest: no coverage checks when running subset of test for a file

### DIFF
--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -11,7 +11,7 @@ function! test#javascript#jest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      let name = '-t '.shellescape(name, 1)
+      let name = '--no-coverage -t '.shellescape(name, 1)
     endif
     return [name, '--', a:position['file']]
   elseif a:type ==# 'file'

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -16,68 +16,68 @@ describe "Jest"
       view +1 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/normal-test.js'
 
       view +2 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/normal-test.js'
 
       view +3 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
     end
 
     it "aliases context to describe"
       view +1 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/context-test.js'
 
       view +2 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/context-test.js'
 
       view +3 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
     end
 
     it "runs CoffeeScript"
       view +1 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/normal-test.coffee'
 
       view +2 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/normal-test.coffee'
 
       view +3 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
     end
 
     it "runs React"
       view +1 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/normal-test.jsx'
 
       view +2 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/normal-test.jsx'
 
       view +3 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
     end
   end
 


### PR DESCRIPTION
It is possible that jest is configured to run coverage checks when running the tests (via the `collectCoverage` setting). This PR disables coverage checking when running a subset of the file since it isn't possible to pass the coverage checks.

### Aside: consider disabling coverage entirely

We may want to consider disabling coverage checks all-together since Jest's coverage checking would likely breakdown for people with coverage expectations below 100%, anyway. I figured, however, I would leave the existing behaviour intact since it is providing some benefit in the 100% case. I wouldn't be opposed to removing it entirely, though, since it shaves off about 200ms per-test-run on my machine. Thoughts?
