### PR TITLE
Add :make! strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ let test#strategy = "dispatch"
 | :-----:                         | :-----:                          | :----------                                                                      |
 | **Basic**&nbsp;(default)        | `basic`                          | Runs test commands with `:!` on Vim, and with `:terminal` on Neovim.             |
 | **Make**                        | `make`                           | Runs test commands with `:make`.                                                 |
+| **Make!**                       | `make_bang`                      | Runs test commands with `:make!`.                                                 |
 | **Neovim**                      | `neovim`                         | Runs test commands with `:terminal` in a split window.                           |
 | **Vim8 Terminal**               | `vimterminal`                    | Runs test commands with `term_start()` in a split window.                        |
 | **[Dispatch]**                  | `dispatch` `dispatch_background` | Runs test commands with `:Dispatch` or `:Dispatch!`.                             |

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -16,6 +16,10 @@ function! test#strategy#basic(cmd) abort
   end
 endfunction
 
+function! test#strategy#make_bang(cmd) abort
+  call s:execute_with_compiler(a:cmd, 'make!')
+endfunction
+
 function! test#strategy#make(cmd) abort
   call s:execute_with_compiler(a:cmd, 'make')
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -233,6 +233,13 @@ be used to automatically find the correct compiler for the command.
 >
   let test#strategy = 'make'
 <
+Make! ~
+
+Runs test commands with `:make!`. If Dispatch.vim plugin is available, it will
+be used to automatically find the correct compiler for the command.
+>
+  let test#strategy = 'make_bang'
+<
 Dispatch ~
 
 Runs test commands with `:Dispatch`. Requires the Dispatch.vim plugin.


### PR DESCRIPTION
This introduces a new strategy, `make_bang` which uses `:make!` instead
of `:make` which differs in behavior by *not* jumping to the first error
if applicable.

I think I hit all the places these are documented, if not let me know.