### PR TITLE
Add spring bin detection to rspec runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ If binstubs are detected, but you don't want to use them, you can turn them off:
 let test#ruby#use_binstubs = 0
 ```
 
+If your binstubs are not instrumented with spring, you can turn on using the `spring` bin (`bin/spring`) directly using:
+
+```vim
+let test#ruby#use_spring_binstub = 1
+```
+
 #### JavaScript
 
 Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies.

--- a/autoload/test/ruby/rspec.vim
+++ b/autoload/test/ruby/rspec.vim
@@ -29,6 +29,8 @@ endfunction
 function! test#ruby#rspec#executable() abort
   if !empty(glob('.zeus.sock'))
     return 'zeus rspec'
+  elseif filereadable('./bin/spring') && get(g:, 'test#ruby#use_spring_binstub', 0)
+    return './bin/spring rspec'
   elseif filereadable('./bin/rspec') && get(g:, 'test#ruby#use_binstubs', 1)
     return './bin/rspec'
   elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)


### PR DESCRIPTION
This allows running tests using spring when the binstubs are not
generated with spring, which is the case in projects where spring causes
many problems and it's not enabled by default.

This is a quick solution that I've been using, which might make sense to others. What I'd really like instead is a runner that could read configuration from projections https://github.com/janko-m/vim-test/issues/297