### PR TITLE
Add option to not load default runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,13 @@ First, add your runner to the list in your `.vimrc`:
 let test#runners = {'MyLanguage': ['MyRunner']}
 ```
 
+Your runner will then be included in the list of runners. To use only your
+runner (excluding all default runners), set this option:
+
+```vim
+let test#merge_default_runners = 0
+```
+
 Second, create `~/.vim/autoload/test/mylanguage/myrunner.vim`, and define the following
 methods:
 

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -419,6 +419,12 @@ You can instruct test.vim to generate absolute file paths:
   let test#filename_modifier = ':~' " ~/Code/my_project/test/models/user_test.rb
 <
 
+You can disable all default runners using:
+
+>
+let test#merge_default_runners = 0
+<
+
 Test.vim relies on you being cd-ed into the project root. However, sometimes
 you may want to execute tests from a different directory than the current
 working directory. You might have a bigger project with many sub-projects,

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -12,27 +12,29 @@ function! s:extend(source, dict) abort
 endfunction
 
 let g:test#runners = get(g:, 'test#runners', {})
-call s:extend(g:test#runners, {
-  \ 'Ruby':       ['Rails', 'M', 'Minitest', 'RSpec', 'Cucumber'],
-  \ 'JavaScript': ['Ava', 'CucumberJS', 'Intern', 'TAP', 'Karma', 'Lab', 'Mocha', 'Jasmine', 'Jest', 'WebdriverIO'],
-  \ 'Python':     ['DjangoTest', 'PyTest', 'PyUnit', 'Nose', 'Nose2'],
-  \ 'Elixir':     ['ExUnit', 'ESpec'],
-  \ 'Elm':        ['ElmTest'],
-  \ 'Erlang':     ['CommonTest'],
-  \ 'Go':         ['GoTest', 'Ginkgo'],
-  \ 'Rust':       ['CargoTest'],
-  \ 'Clojure':    ['FireplaceTest'],
-  \ 'CSharp':     ['Xunit', 'DotnetTest'],
-  \ 'Shell':      ['Bats'],
-  \ 'Swift':      ['SwiftPM'],
-  \ 'VimL':       ['Themis', 'VSpec', 'Vader'],
-  \ 'Lua':        ['Busted'],
-  \ 'PHP':        ['Codeception', 'Dusk', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],
-  \ 'Perl':       ['Prove'],
-  \ 'Racket':     ['RackUnit'],
-  \ 'Java':       ['MavenTest'],
-  \ 'Crystal':    ['CrystalSpec'],
-\})
+if get(g:, 'test#merge_default_runners', 1)
+  call s:extend(g:test#runners, {
+    \ 'Ruby':       ['Rails', 'M', 'Minitest', 'RSpec', 'Cucumber'],
+    \ 'JavaScript': ['Ava', 'CucumberJS', 'Intern', 'TAP', 'Karma', 'Lab', 'Mocha', 'Jasmine', 'Jest', 'WebdriverIO'],
+    \ 'Python':     ['DjangoTest', 'PyTest', 'PyUnit', 'Nose', 'Nose2'],
+    \ 'Elixir':     ['ExUnit', 'ESpec'],
+    \ 'Elm':        ['ElmTest'],
+    \ 'Erlang':     ['CommonTest'],
+    \ 'Go':         ['GoTest', 'Ginkgo'],
+    \ 'Rust':       ['CargoTest'],
+    \ 'Clojure':    ['FireplaceTest'],
+    \ 'CSharp':     ['Xunit', 'DotnetTest'],
+    \ 'Shell':      ['Bats'],
+    \ 'Swift':      ['SwiftPM'],
+    \ 'VimL':       ['Themis', 'VSpec', 'Vader'],
+    \ 'Lua':        ['Busted'],
+    \ 'PHP':        ['Codeception', 'Dusk', 'PHPUnit', 'Behat', 'PHPSpec', 'Kahlan', 'Peridot'],
+    \ 'Perl':       ['Prove'],
+    \ 'Racket':     ['RackUnit'],
+    \ 'Java':       ['MavenTest'],
+    \ 'Crystal':    ['CrystalSpec'],
+  \})
+endif
 
 let g:test#custom_strategies = get(g:, 'test#custom_strategies', {})
 let g:test#custom_transformations = get(g:, 'test#custom_transformations', {})


### PR DESCRIPTION
Add option to not load default runners

This adds `test#merge_default_runners` with a default value of 1 to keep
the current behavior. It can be set to 0 to disable all default runners.

This is useful if you want to include your own runners but the default
runners end up being picked up instead.