### PR TITLE
Add option to select which runners to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,19 @@ function! test#mylanguage#myrunner#executable()
 
 See [`autoload/test`](/autoload/test) for examples.
 
+## Choosing which runners to load
+
+All runners are loaded by default. To select which runners to load, set this
+option:
+
+```vim
+let test#enabled_runners = ["mylanguage#myrunner", "ruby#rspec"]
+```
+
+All other runners will not be loaded.
+
+Note that for your own custom runners, you still need to set `test#runners`.
+
 ## Running tests
 
 Tests are run using a Ruby test runner, so you'll have to have Ruby installed.

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -115,6 +115,11 @@ function! test#determine_runner(file) abort
   for [language, runners] in items(g:test#runners)
     for runner in runners
       let runner = tolower(language).'#'.tolower(runner)
+      if exists("g:test#enabled_runners")
+        if index(g:test#enabled_runners, runner) < 0
+          continue
+        endif
+      endif
       if test#base#test_file(runner, fnamemodify(a:file, ':.'))
         return runner
       endif

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -419,6 +419,16 @@ You can instruct test.vim to generate absolute file paths:
   let test#filename_modifier = ':~' " ~/Code/my_project/test/models/user_test.rb
 <
 
+To select which runners to load, set this option:
+
+```vim
+let test#enabled_runners = ["mylanguage#myrunner", "ruby#rspec"]
+```
+
+All other runners will not be loaded.
+
+Note that for your own custom runners, you still need to set `test#runners`.
+
 Test.vim relies on you being cd-ed into the project root. However, sometimes
 you may want to execute tests from a different directory than the current
 working directory. You might have a bigger project with many sub-projects,


### PR DESCRIPTION
If `test#enabled_runners` is set, only runners from that list will be
loaded.

It turns out using the namespace for the runner name makes the code simpler.

As discussed on #300 