### PR TITLE
Add g:test#vimterminal_persist_session option

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -56,8 +56,22 @@ function! test#strategy#neovim(cmd) abort
 endfunction
 
 function! test#strategy#vimterminal(cmd) abort
-  botright new
-  call term_start(['/bin/sh', '-c', a:cmd], {'curwin':1})
+  if exists("g:test#vimterminal_persist_session") && g:test#vimterminal_persist_session
+    if !exists("g:test#vimterminal_shell")
+      let g:test#vimterminal_shell = &shell
+    endif
+
+    if !exists("g:test#vimterminal_buffer") || !bufexists(g:test#vimterminal_buffer)
+      let g:test#vimterminal_buffer =
+            \ term_start(g:test#vimterminal_shell, {'term_finish': 'close'})
+      wincmd p
+    endif
+
+    call term_sendkeys(g:test#vimterminal_buffer, a:cmd . "\<cr>")
+  else
+    botright new
+    call term_start(['/bin/sh', '-c', a:cmd], {'curwin':1})
+  endif
 endfunction
 
 function! test#strategy#neoterm(cmd) abort


### PR DESCRIPTION
This option opens an interactive shell in a terminal buffer and sends
test commands using term_sendkeys(). This is useful when the user wants
to have their history of test runs available in a single terminal
buffer, rather than opening a fresh one every time.

This is my preferred behavior, so I figured I would see if others found it useful. Otherwise I'll just implement it as a custom strategy.