### PR TITLE
Add vertical neovim strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -55,6 +55,13 @@ function! test#strategy#neovim(cmd) abort
   startinsert
 endfunction
 
+function! test#strategy#neovim_vertical(cmd) abort
+  vertical new
+  call termopen(a:cmd)
+  au BufDelete <buffer> wincmd p " switch back to last window
+  startinsert
+endfunction
+
 function! test#strategy#vimterminal(cmd) abort
   botright new
   call term_start(['/bin/sh', '-c', a:cmd], {'curwin':1})


### PR DESCRIPTION
Add Vertical Neovim strategy to run tests in a terminal in a vertical, instead of the default horizontal.
 
Sorry for this lousy PR, but before I improve it I'd like to know if you are accepting this kind of strategies at the repository.

Other options would be to just document this kind of strategy for the user to add it to their init.vim or to add options to the basic `neovim` strategy. Please, let me know what to you think and I will improve it.