### PR TITLE
fix(csharp): add missing flag arg in substitute cmd

### DIFF
--- a/autoload/test/csharp.vim
+++ b/autoload/test/csharp.vim
@@ -14,7 +14,7 @@ function! test#csharp#get_project_path(file) abort
     let l:filepath_parts = split(l:filepath, s:slash)
     let l:search_for_csproj = len(l:filepath_parts) > 1
     " only want the forward slash at the root dir for non-windows machines
-    let l:filepath = substitute(s:slash, '\', '').join(l:filepath_parts[0:-2], s:slash)
+    let l:filepath = substitute(s:slash, '\', '', '').join(l:filepath_parts[0:-2], s:slash)
     let l:project_files = s:get_project_files(l:filepath)
   endwhile
 


### PR DESCRIPTION
This PR adds the missing flags argument in the `substitute` command that only seems to be problematic in windows. The reason I probably missed this is all tests were run on WSL on windows 10 and passed. I was even able to run actual commands in a dotnet project. However, moving over to windows I get the error below that is fixed with this PR, I really wanted to create a test against the csharp.vim file that I could run on windows, but I could not get vim-flavor to run on windows.

![image](https://user-images.githubusercontent.com/8404957/43279121-149921a8-90db-11e8-880d-83ebb79179e9.png)