### PR TITLE
Add minimal scala support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ runners are supported:
 | **Racket**     | RackUnit                                                                      | `rackunit`                                                                                      |
 | **Ruby**       | Cucumber, [M], [Minitest][minitest], Rails, RSpec                             | `cucumber`, `m`, `minitest`, `rails`, `rspec`                                                   |
 | **Rust**       | Cargo                                                                         | `cargotest`                                                                                     |
+| **Scala**      | SBT                                                                           | `sbttest`                                                                                       |
 | **Shell**      | Bats                                                                          | `bats`                                                                                          |
 | **Swift**      | Swift Package Manager                                                         | `swiftpm`                                                                                       |
 | **VimScript**  | Vader.vim, VSpec, Themis                                                      | `vader`, `vspec`, `themis`                                                                      |

--- a/autoload/test/scala.vim
+++ b/autoload/test/scala.vim
@@ -1,0 +1,4 @@
+let test#scala#patterns = {
+  \ 'test':      ['\v^\s*test\((.*)\)'],
+  \ 'namespace': [],
+\}

--- a/autoload/test/scala/sbttest.vim
+++ b/autoload/test/scala/sbttest.vim
@@ -1,10 +1,11 @@
 if !exists('g:test#scala#sbttest#file_pattern')
-  let g:test#scala#sbttest#file_pattern = '\v^.*.scala$'
+  let g:test#scala#sbttest#file_pattern = '\v^(.*test.*|.*suite.*)\c\.scala$'
 endif
 
 " Returns true if the given file belongs to your test runner
 function! test#scala#sbttest#test_file(file) abort
-  return a:file =~? g:test#scala#sbttest#file_pattern
+  let current_file = fnamemodify(a:file, ':t')
+  return current_file =~? g:test#scala#sbttest#file_pattern
 endfunction
 
 " Returns test runner's arguments which will run the current file and/or line

--- a/autoload/test/scala/sbttest.vim
+++ b/autoload/test/scala/sbttest.vim
@@ -1,0 +1,39 @@
+if !exists('g:test#scala#sbttest#file_pattern')
+  let g:test#scala#sbttest#file_pattern = '\v^.*.scala$'
+endif
+
+" Returns true if the given file belongs to your test runner
+function! test#scala#sbttest#test_file(file) abort
+  return a:file =~? g:test#scala#sbttest#file_pattern
+endfunction
+
+" Returns test runner's arguments which will run the current file and/or line
+function! test#scala#sbttest#build_position(type, position) abort
+  let filename = fnamemodify(a:position['file'], ':t:r')
+
+  if a:type ==# 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      return ['"test:test-only *' . filename .' -- -z ' . name . '"']
+    else
+      return ['"test:test-only *' . filename . '"']
+    endif
+  elseif a:type ==# 'file'
+    return ['"test:test-only *' . filename . '"']
+  else
+    return []
+  endif
+endfunction
+
+function! test#scala#sbttest#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#scala#sbttest#executable() abort
+  return 'sbt'
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#scala#patterns)
+  return escape(join(name['test'], ''), '"')
+endfunction

--- a/autoload/test/scala/sbttest.vim
+++ b/autoload/test/scala/sbttest.vim
@@ -14,14 +14,14 @@ function! test#scala#sbttest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      return ['"test:test-only *' . filename .' -- -z ' . name . '"']
+      return ['"testOnly *' . filename .' -- -z ' . name . '"']
     else
-      return ['"test:test-only *' . filename . '"']
+      return ['"testOnly *' . filename . '"']
     endif
   elseif a:type ==# 'file'
-    return ['"test:test-only *' . filename . '"']
+    return ['"testOnly *' . filename . '"']
   else
-    return []
+    return ['"test"']
   endif
 endfunction
 
@@ -35,5 +35,5 @@ endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#scala#patterns)
-  return escape(join(name['test'], ''), '"')
+  return escape(escape(join(name['test'], ""), '"'), "'")
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -203,6 +203,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:MavenTest*
 :MavenTest [args]            Uses the `mvn` `test` command.
 
+                                                *test-:SbtTest*
+:SbtTest [args]            Uses the `sbt` `test/testOnly` command.
+
                                                 *test-:CrystalSpec*
 :CrystalSpec [args]          Uses the `crystal` `spec` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -24,6 +24,7 @@ let g:test#default_runners = {
   \ 'Perl':       ['Prove'],
   \ 'Racket':     ['RackUnit'],
   \ 'Java':       ['MavenTest'],
+  \ 'Scala':      ['Sbttest'],
   \ 'Crystal':    ['CrystalSpec'],
 \}
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -24,7 +24,7 @@ let g:test#default_runners = {
   \ 'Perl':       ['Prove'],
   \ 'Racket':     ['RackUnit'],
   \ 'Java':       ['MavenTest'],
-  \ 'Scala':      ['Sbttest'],
+  \ 'Scala':      ['SbtTest'],
   \ 'Crystal':    ['CrystalSpec'],
 \}
 

--- a/spec/fixtures/sbt/FixtureSuite.scala
+++ b/spec/fixtures/sbt/FixtureSuite.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/fixtures/sbt/FixtureTest.scala
+++ b/spec/fixtures/sbt/FixtureTest.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/fixtures/sbt/FixtureTestSuite.scala
+++ b/spec/fixtures/sbt/FixtureTestSuite.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/fixtures/sbt/SuiteFixture.scala
+++ b/spec/fixtures/sbt/SuiteFixture.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/fixtures/sbt/TestFixture.scala
+++ b/spec/fixtures/sbt/TestFixture.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/fixtures/sbt/whatever_suite_smth.scala
+++ b/spec/fixtures/sbt/whatever_suite_smth.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/fixtures/sbt/whatever_test_smth.scala
+++ b/spec/fixtures/sbt/whatever_test_smth.scala
@@ -1,0 +1,64 @@
+package fixture
+
+import org.scalatest.FunSuite
+
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FixtureTestSuite extends FunSuite {
+
+  trait TestMath{
+    val valueIntOne: Int = 3
+    val valueIntTwo: Int = 5
+    val valueDoubleOne: Double = 8.0
+    val valueDoubleTwo: Double = 13.0
+    val valueStringOne = "a"
+    val valueStringTwo = "b"
+  }
+
+  test("Assert 'add' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.add(valueIntOne, valueIntTwo)
+      assert(8 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'add' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.add(valueDoubleOne, valueDoubleTwo)
+      assert(21.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert 'mul' works for Int and returns Int") {
+    new TestMath{
+      val intUnderTest = SimpleMath.mul(valueIntOne, valueIntTwo)
+      assert(15 == intUnderTest)
+      assert(intUnderTest.isInstanceOf[Int])
+    }
+  }
+
+  test("Assert 'mul' works for Double and returns Double") {
+    new TestMath{
+      val doubleUnderTest = SimpleMath.mul(valueDoubleOne, valueDoubleTwo)
+      assert(104.0 == doubleUnderTest)
+      assert(doubleUnderTest.isInstanceOf[Double])
+    }
+  }
+
+  test("Assert neither 'add' nor 'mul' work on String") {
+    new TestMath{
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.add(valueStringOne, valueStringTwo)
+      }
+      assertThrows[IllegalArgumentException] {
+        SimpleMath.mul(valueStringOne, valueStringTwo)
+      }
+    }
+  }
+
+}

--- a/spec/sbttest_spec.vim
+++ b/spec/sbttest_spec.vim
@@ -15,56 +15,56 @@ describe "SBT"
     view FixtureTest.scala
     TestFile
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTest"'
   end
 
   it "runs when filename matches *Suite.scala"
     view FixtureSuite.scala
     TestFile
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "testOnly *FixtureSuite"'
   end
 
   it "runs when filename matches Test*.scala"
     view TestFixture.scala
     TestFile
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "testOnly *TestFixture"'
   end
 
   it "runs when filename matches Suite*.scala"
     view SuiteFixture.scala
     TestFile
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "testOnly *SuiteFixture"'
   end
 
   it "runs when filename matches *test*.scala"
     view whatever_test_smth.scala
     TestFile
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "testOnly *whatever_test_smth"'
   end
 
   it "runs when filename matches *suite*.scala"
     view whatever_suite_smth.scala
     TestFile
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "testOnly *whatever_suite_smth"'
   end
 
   it "runs nearest tests"
     view +32 FixtureTestSuite.scala
     TestNearest
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite \"Assert \'add\' works for Double and returns Double\""'
+    Expect g:test#last_command == "sbt \"testOnly *FixtureTestSuite \\\"Assert \'add\' works for Double and returns Double\\\""
   end
 
   it "runs a suite"
     view FixtureTestSuite.scala
     TestSuite
 
-    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+    Expect g:test#last_command == 'sbt "test\"'
   end
 
 end

--- a/spec/sbttest_spec.vim
+++ b/spec/sbttest_spec.vim
@@ -1,0 +1,70 @@
+source spec/support/helpers.vim
+
+describe "SBT"
+
+  before
+    cd spec/fixtures/sbt
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs when filename matches *Test.scala"
+    view FixtureTest.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+  it "runs when filename matches *Suite.scala"
+    view FixtureSuite.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+  it "runs when filename matches Test*.scala"
+    view TestFixture.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+  it "runs when filename matches Suite*.scala"
+    view SuiteFixture.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+  it "runs when filename matches *test*.scala"
+    view whatever_test_smth.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+  it "runs when filename matches *suite*.scala"
+    view whatever_suite_smth.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+  it "runs nearest tests"
+    view +32 FixtureTestSuite.scala
+    TestNearest
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite \"Assert \'add\' works for Double and returns Double\""'
+  end
+
+  it "runs a suite"
+    view FixtureTestSuite.scala
+    TestSuite
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite"'
+  end
+
+end

--- a/spec/sbttest_spec.vim
+++ b/spec/sbttest_spec.vim
@@ -57,14 +57,14 @@ describe "SBT"
     view +32 FixtureTestSuite.scala
     TestNearest
 
-    Expect g:test#last_command == "sbt \"testOnly *FixtureTestSuite \\\"Assert \'add\' works for Double and returns Double\\\""
+    Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite -- -z \"Assert '."\\'".'add'."\\'".' works for Double and returns Double\""'
   end
 
   it "runs a suite"
     view FixtureTestSuite.scala
     TestSuite
 
-    Expect g:test#last_command == 'sbt "test\"'
+    Expect g:test#last_command == 'sbt "test"'
   end
 
 end


### PR DESCRIPTION
Hey janko-m,

First of all, thank you for the brilliant work, I am a huge fan, and use vim-test regularly to test my python, ruby and java!
Should you choose to include my contribution for scala testing through sbt, it would be my greatest pleasure.
I tested the solution, and it works fine for me, but as scala imposes way less formatting restrictions compared to java tests for instance, it is hard to create a file pattern regex to match all possible cases. If (when) I find a better one, I will definitely let you know.
Also, I am mostly using maven as scala is a mixin, rather than my primary tool. I will cut some time in the future to attach maven test to scala as well.

Thank you once again, 

with my best wishes, 

Alex T