### PR TITLE
jest: make consistent by disabling coverage everywhere

### DIFF
--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -11,11 +11,11 @@ function! test#javascript#jest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      let name = '--no-coverage -t '.shellescape(name, 1)
+      let name = '-t '.shellescape(name, 1)
     endif
-    return [name, '--', a:position['file']]
+    return ['--no-coverage', name, '--', a:position['file']]
   elseif a:type ==# 'file'
-    return ['--', a:position['file']]
+    return ['--no-coverage', '--', a:position['file']]
   else
     return []
   endif

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -86,14 +86,14 @@ describe "Jest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'jest -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest --no-coverage -- __tests__/normal-test.js'
   end
 
   it "runs file tests"
     view __tests__/normal-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest --no-coverage -- __tests__/normal-test.js'
   end
 
   it "runs test suites"
@@ -107,7 +107,7 @@ describe "Jest"
     view outside-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest -- outside-test.js'
+    Expect g:test#last_command == 'jest --no-coverage -- outside-test.js'
   end
 
 end


### PR DESCRIPTION
The jest runner was disabling coverage under some test-run scenarios but not others. Keep things consistent by always disabling coverage.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] ~Update the README accordingly~
- [ ] ~Update the Vim documentation in `doc/test.txt`~
