### PR TITLE
Add the ability to configure Vim's terminal position

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,15 +253,16 @@ let test#ruby#rspec#options = {
 \}
 ```
 
-### Neovim terminal position
+### Vim8 / Neovim terminal position
 
-The `neovim` strategy will open a split window on the bottom by default, but
+Both the `neovim` and `Vim8 Terminal` strategy will open a split window on the bottom by default, but
 you can configure a different position:
 
 ```vim
+" for neovim
 let test#neovim#term_position = "topleft"
-" or
-let test#neovim#term_position = "belowright"
+" or for Vim8
+let test#vim#term_position = "belowright"
 ```
 
 For full list of variants, see `:help opening-window`.

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -57,7 +57,8 @@ function! test#strategy#neovim(cmd) abort
 endfunction
 
 function! test#strategy#vimterminal(cmd) abort
-  botright new
+  let term_position = get(g:, 'test#vim#term_position', 'botright')
+  execute term_position . ' new'
   call term_start(['/bin/sh', '-c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
 endfunction
 

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -452,11 +452,16 @@ working directory for running tests:
 >
   let test#project_root = "/path/to/your/project"
 <
-If you're using the neovim strategy, you can easily configure the position of
-the terminal split window (see `:help opening-window`):
+If you're using either the Vim8 Terminal or Neovim strategy, you can easily configure the position of
+the terminal split window (see `:help opening-window`) with:
+>
+  let test#vim#term_position = "topleft"
+<
+for vim and
 >
   let test#neovim#term_position = "topleft"
 <
+for neovim
 
 PROJECTIONIST INTEGRATION                       *test-projectionist*
 


### PR DESCRIPTION
This PR adds a way to configure the terminal position for vim's built-in terminal.
It'd also add the new test#vim#term_position variable which IMHO is redundant since the same-ish variable exists for neovim. 

Personally I think it would be better to have one test#vim#term_{split,position} variable and use it for both, vim and neovim.


but this decision is up to @janko-m 