### PR TITLE
vimterminal: switch back to previous window upon exiting the test runner buffer

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -60,6 +60,7 @@ function! test#strategy#vimterminal(cmd) abort
   let term_position = get(g:, 'test#vim#term_position', 'botright')
   execute term_position . ' new'
   call term_start(['/bin/sh', '-c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
+  au BufLeave <buffer> wincmd p
   nnoremap <buffer> <Enter> :q<CR>
   redraw
   echo "Press <Enter> to exit test runner terminal (<Ctrl-C> first if command is still running)"

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -60,6 +60,9 @@ function! test#strategy#vimterminal(cmd) abort
   let term_position = get(g:, 'test#vim#term_position', 'botright')
   execute term_position . ' new'
   call term_start(['/bin/sh', '-c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
+  nnoremap <buffer> <Enter> :q<CR>
+  redraw
+  echo "Press <Enter> to exit test runner terminal (<Ctrl-C> first if command is still running)"
 endfunction
 
 function! test#strategy#neoterm(cmd) abort


### PR DESCRIPTION
I initially tried to use BufDelete as per the neovim strategy, but it
didn't work. BufLeave works well for me.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`