### PR TITLE
vimterminal: use command for buffer name

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -58,7 +58,7 @@ endfunction
 
 function! test#strategy#vimterminal(cmd) abort
   botright new
-  call term_start(['/bin/sh', '-c', a:cmd], {'curwin':1})
+  call term_start(['/bin/sh', '-c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
 endfunction
 
 function! test#strategy#neoterm(cmd) abort


### PR DESCRIPTION
Otherwise, the buffer is just called "/bin/sh" which is less useful.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
