### PR TITLE
TestNearest handles "Scenario Outline" for Behat

### DIFF
--- a/autoload/test/php/behat.vim
+++ b/autoload/test/php/behat.vim
@@ -41,7 +41,7 @@ function! test#php#behat#executable() abort
 endfunction
 
 function! s:nearest_test(position) abort
-  let patterns = {'test': ['\vScenario: (.*)'], 'namespace': []}
+  let patterns = {'test': ['\vScenario%(\s*Outline)?: (.*)'], 'namespace': []}
   let name = test#base#nearest_test(a:position, patterns)
   return join(name['test'])
 endfunction

--- a/spec/behat_spec.vim
+++ b/spec/behat_spec.vim
@@ -21,6 +21,16 @@ describe "Behat"
     TestNearest
 
     Expect g:test#last_command == 'behat normal.feature --name ''Addition'''
+
+    view +7 normal.feature
+    TestNearest
+
+    Expect g:test#last_command == 'behat normal.feature --name ''Substraction'''
+
+    view +11 normal.feature
+    TestNearest
+
+    Expect g:test#last_command == 'behat normal.feature --name ''Multiplication'''
   end
 
   it "runs file tests"

--- a/spec/fixtures/behat/normal.feature
+++ b/spec/fixtures/behat/normal.feature
@@ -2,3 +2,11 @@ Feature: Numbers
   Scenario: Addition
     When I add 1 and 1
     Then I should get 2
+
+  Scenario Outline: Substraction
+    When I substract 1 from 2
+    Then A should get 1
+
+  Scenario: Multiplication
+    When I multiply 2 and 2
+    Then I should get 4


### PR DESCRIPTION
First of all: thanks for the work done, great plugin!

The `:TestNearest` command does not handle "Scenario Outline"
I updated the regex to correct that and the specs/fixture for Behat.

I checked the update README and doc checkboxes even if I didn't.
Because there is nothing do add there, no new feature only a bug-fix.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
